### PR TITLE
Add travel planner settings and trip summary documentation

### DIFF
--- a/ns-api-test/package-lock.json
+++ b/ns-api-test/package-lock.json
@@ -8,9 +8,17 @@
       "name": "ns-api-test",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-checkbox": "^1.1.4",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-label": "^2.1.2",
+        "@radix-ui/react-scroll-area": "^1.2.3",
+        "@radix-ui/react-select": "^2.1.6",
+        "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-switch": "^1.1.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "framer-motion": "^12.6.3",
         "lucide-react": "^0.487.0",
         "next": "15.2.4",
@@ -240,6 +248,40 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1001,6 +1043,92 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "dev": true
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
+      "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.4.tgz",
+      "integrity": "sha512-wP0CPAHq+P5I4INKe3hJrIa1WoNqqrejzW+zoU0rOvo1b9gDEJJFl2rYfO1PYJUQCc2H1WZxIJmyv9BS8i5fLw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.2.tgz",
+      "integrity": "sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
@@ -1016,11 +1144,369 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.6.tgz",
+      "integrity": "sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.2.tgz",
+      "integrity": "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.2.tgz",
+      "integrity": "sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
+      "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.3.tgz",
+      "integrity": "sha512-l7+NNBfBYYJa9tNqVcP2AGvxdE3lmE6kFTBXdvHgUaZuy+4wGCL1Cl2AfaR7RKyimj7lZURGLwFO59k4eBnDJQ==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.6.tgz",
+      "integrity": "sha512-T6ajELxRvTuAMWH0YmRJ1qez+x4/7Nq7QIx7zJ0VK3qaEWdnWpNbEDnmWldG1zBDwqrLy5aLMUWcoGirVj5kMg==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.2.tgz",
+      "integrity": "sha512-oZfHcaAp2Y6KFBX6I5P1u7CQoy4lheCGiYj+pGFrHy8E/VNRb5E39TkTr3JrV520csPBTZjkuKFdEsjS5EUNKQ==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
       "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
-      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.1"
       },
@@ -1033,6 +1519,171 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.3.tgz",
+      "integrity": "sha512-1nc+vjEOQkJVsJtWPSiISGT6OKm4SiOdjMo+/icLxo2G4vxz1GntC5MzfL4v8ey9OEfw787QCD1y3mUv0NiFEQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.2.tgz",
+      "integrity": "sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1101,7 +1752,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -1669,6 +2320,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2334,6 +2996,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -2410,6 +3081,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3577,6 +4253,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -5333,6 +6017,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.3.tgz",
+      "integrity": "sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6403,6 +7153,47 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/ns-api-test/package.json
+++ b/ns-api-test/package.json
@@ -10,9 +10,17 @@
     "analyze": "cross-env ANALYZE=true next build"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.1.4",
+    "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-scroll-area": "^1.2.3",
+    "@radix-ui/react-select": "^2.1.6",
+    "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-switch": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.6.3",
     "lucide-react": "^0.487.0",
     "next": "15.2.4",

--- a/ns-api-test/parse_travel_plan.js
+++ b/ns-api-test/parse_travel_plan.js
@@ -1,0 +1,169 @@
+const fs = require('fs');
+const path = require('path');
+
+// Use the current directory of the script to find the input file
+const filePath = path.join(__dirname, 'travel_planner_output.txt');
+const outputFilePath = path.join(__dirname, 'travel_summary.txt');
+
+// Helper function to format date/time string into a readable format
+function formatDateTime(dateTimeString) {
+    if (!dateTimeString) return 'N/A';
+    try {
+        const date = new Date(dateTimeString);
+        // Using Dutch locale and Amsterdam timezone for appropriate formatting
+        return date.toLocaleString('nl-NL', {
+            year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit',
+            timeZone: 'Europe/Amsterdam'
+        });
+    } catch (e) {
+        console.warn(`Warning: Could not parse date-time: ${dateTimeString}`);
+        return dateTimeString; // Return original string if parsing fails
+    }
+}
+
+// Helper function to format only the time part of a date/time string
+function formatTime(dateTimeString) {
+    if (!dateTimeString) return 'N/A';
+     try {
+        const date = new Date(dateTimeString);
+        return date.toLocaleTimeString('nl-NL', {
+            hour: '2-digit', minute: '2-digit',
+            timeZone: 'Europe/Amsterdam'
+        });
+    } catch (e) {
+        console.warn(`Warning: Could not parse time: ${dateTimeString}`);
+        return dateTimeString; // Return original string if parsing fails
+    }
+}
+
+try {
+    // Read the JSON file content
+    const rawData = fs.readFileSync(filePath, 'utf8');
+    // Parse the JSON data
+    const travelData = JSON.parse(rawData);
+
+    let outputContent = ''; // Initialize string to hold the output
+
+    // Basic validation of the parsed data
+    if (!travelData || !travelData.trips || !Array.isArray(travelData.trips) || travelData.trips.length === 0) {
+        console.log("No valid travel trips found in the data."); // Keep this console log for immediate feedback
+        process.exit(0); // Exit gracefully if no trips are found
+    }
+
+    outputContent += "--- Travel Plan Summary ---\n";
+
+    // --- Extract and Display Settings (derived from the first trip's data) ---
+    const firstTripForSettings = travelData.trips[0];
+    if (firstTripForSettings.legs && firstTripForSettings.legs.length > 0) {
+        const firstLeg = firstTripForSettings.legs[0];
+        // Find the very last leg of the first trip for the destination
+        const lastLeg = firstTripForSettings.legs[firstTripForSettings.legs.length - 1];
+        outputContent += "\n=== Planning Settings ===\n";
+        outputContent += `Origin:      ${firstLeg.origin?.name || 'N/A'}\n`;
+        outputContent += `Destination: ${lastLeg.destination?.name || 'N/A'}\n`;
+        // Display the planned departure time as the requested time
+        outputContent += `Time:        ${formatDateTime(firstLeg.origin?.plannedDateTime) || 'N/A'}\n`;
+    } else {
+         outputContent += "\n=== Planning Settings ===\n";
+         outputContent += "Could not determine planning settings from the data (incomplete first trip).\n";
+    }
+
+
+    // --- Iterate through and Display Each Trip Option ---
+    travelData.trips.forEach((trip, index) => {
+        outputContent += `\n=== Trip Option ${index + 1} ===\n`;
+
+        // Check if the trip has legs
+        if (!trip.legs || !Array.isArray(trip.legs) || trip.legs.length === 0) {
+            outputContent += "  Trip data is incomplete (missing legs).\n";
+            return; // Skip to the next trip if legs are missing
+        }
+
+        // Determine overall departure and arrival from the first and last leg
+        const overallDepartureTime = trip.legs[0].origin?.plannedDateTime;
+        const overallArrivalTime = trip.legs[trip.legs.length - 1].destination?.plannedDateTime;
+
+        outputContent += `Departure:   ${formatDateTime(overallDepartureTime)}\n`;
+        outputContent += `Arrival:     ${formatDateTime(overallArrivalTime)}\n`;
+        outputContent += `Duration:    ${trip.plannedDurationInMinutes ?? 'N/A'} minutes\n`;
+        outputContent += `Transfers:   ${trip.transfers ?? 'N/A'}\n`; // Use nullish coalescing for 0 transfers
+        outputContent += `Status:      ${trip.status || 'N/A'}\n`;
+
+        // Display General Trip Messages
+        if (trip.messages && trip.messages.length > 0) {
+            outputContent += "Messages:\n";
+            trip.messages.forEach(msg => outputContent += `  - ${msg.message || 'No message text'}\n`);
+        }
+
+        // Display Trip-Specific Labels/Notes (like supplements)
+         if (trip.labelListItems && trip.labelListItems.length > 0) {
+            outputContent += "Notes:\n";
+            trip.labelListItems.forEach(label => outputContent += `  - ${label.label || 'No label text'}\n`);
+        }
+
+        outputContent += "\n  --- Legs ---\n";
+        trip.legs.forEach((leg, legIndex) => {
+            // Prefer actual track, fallback to planned track, else 'N/A'
+            const depTrack = leg.origin?.actualTrack || leg.origin?.plannedTrack || 'N/A';
+            const arrTrack = leg.destination?.actualTrack || leg.destination?.plannedTrack || 'N/A';
+            // Format times
+            const depTime = formatTime(leg.origin?.plannedDateTime);
+            const arrTime = formatTime(leg.destination?.plannedDateTime);
+
+            outputContent += `  Leg ${legIndex + 1}: ${leg.product?.shortCategoryName || 'N/A'} ${leg.name || ''} (Direction: ${leg.direction || 'N/A'})\n`;
+            outputContent += `    ${depTime} Depart ${leg.origin?.name || 'N/A'} (Track ${depTrack})\n`;
+            outputContent += `    ${arrTime} Arrive ${leg.destination?.name || 'N/A'} (Track ${arrTrack})\n`;
+
+            // Display Leg-Specific Notes (only if marked for presentation)
+            if (leg.notes && leg.notes.length > 0) {
+                 leg.notes.forEach(note => {
+                     // Check if the note has a value and is meant to be shown
+                     if (note.value && note.isPresentationRequired !== false) {
+                         outputContent += `      Note: ${note.value}\n`;
+                     }
+                 });
+            }
+             // Display Product-Specific Notes (like supplements, only if marked for presentation)
+            if (leg.product?.notes) {
+                leg.product.notes.forEach(noteGroup => {
+                    if (Array.isArray(noteGroup)) {
+                        noteGroup.forEach(note => {
+                            // Specifically look for supplement notes or others marked for presentation
+                            if (note.value && note.isPresentationRequired !== false && note.key === 'PRODUCT_SUPPLEMENT') {
+                                outputContent += `      Note: ${note.value}\n`;
+                            }
+                        });
+                    }
+                });
+            }
+             // Display Transfer Messages associated with this leg (info for getting to the *next* leg)
+            if (leg.transferMessages && leg.transferMessages.length > 0) {
+                outputContent += "    Transfer Info:\n";
+                leg.transferMessages.forEach(msg => outputContent += `      - ${msg.message || 'No message text'}\n`);
+            }
+
+            outputContent += '\n'; // Add spacing for readability between legs
+        });
+    });
+
+    outputContent += "--- End of Summary ---\n";
+
+    // Write the accumulated output to the file
+    fs.writeFileSync(outputFilePath, outputContent, 'utf8');
+    console.log(`Travel summary successfully written to ${outputFilePath}`); // Log success to console
+
+} catch (error) {
+    // Handle potential errors during file reading or JSON parsing
+    if (error.code === 'ENOENT') {
+        console.error(`Error: Input file not found at ${filePath}`);
+        console.error("Please ensure 'travel_planner_output.txt' exists in the same directory as the script.");
+    } else if (error instanceof SyntaxError) {
+        console.error(`Error: Could not parse JSON data in ${filePath}.`);
+        console.error("Please ensure the file contains valid JSON.");
+    } else {
+        // Catch-all for other unexpected errors
+        console.error("An unexpected error occurred:", error);
+    }
+    process.exit(1); // Exit with a non-zero code to indicate failure
+}

--- a/ns-api-test/src/app/api/plan-trip/route.ts
+++ b/ns-api-test/src/app/api/plan-trip/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+    const apiKey = process.env.NSR_API_KEY; // Use the correct environment variable name
+
+    if (!apiKey) {
+        console.error('NSR_API_KEY environment variable is not set.'); // Update error message
+        return NextResponse.json({ error: 'Server configuration error: API key missing.' }, { status: 500 });
+    }
+
+    try {
+        const settings = await request.json();
+
+        // Construct query parameters, filtering out null/undefined/empty values
+        const params = new URLSearchParams();
+        for (const key in settings) {
+            const value = settings[key];
+            if (value !== null && value !== undefined && value !== '') {
+                // Handle boolean values explicitly
+                if (typeof value === 'boolean') {
+                    params.append(key, String(value));
+                }
+                // Handle arrays (assuming comma-separated string format for NS API)
+                else if (Array.isArray(value)) {
+                     if (value.length > 0) {
+                        params.append(key, value.join(','));
+                     }
+                }
+                // Handle other types
+                else {
+                    params.append(key, String(value));
+                }
+            }
+        }
+
+        const apiUrl = `https://gateway.apiportal.ns.nl/reisinformatie-api/api/v3/trips?${params.toString()}`;
+
+        console.log(`Fetching from NS API: ${apiUrl}`); // Log the URL for debugging (without API key)
+
+        const response = await fetch(apiUrl, {
+            method: 'GET',
+            headers: {
+                'Ocp-Apim-Subscription-Key': apiKey,
+                'Accept': 'application/json', // Ensure we request JSON
+            },
+            cache: 'no-store', // Ensure fresh data for trip planning
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            console.error(`NS API Error (${response.status}): ${errorText}`);
+            // Try to parse error if it's JSON, otherwise return text
+            let errorJson = null;
+            try {
+                errorJson = JSON.parse(errorText);
+            } catch (e) {
+                // Ignore parsing error
+            }
+            return NextResponse.json(
+                { error: `Failed to fetch trip data from NS API. Status: ${response.status}`, details: errorJson || errorText },
+                { status: response.status }
+            );
+        }
+
+        const data = await response.json();
+        return NextResponse.json(data);
+
+    } catch (error) {
+        console.error('Error in /api/plan-trip:', error);
+        let errorMessage = 'Internal Server Error';
+        if (error instanceof Error) {
+            errorMessage = error.message;
+        }
+        return NextResponse.json({ error: 'Failed to process trip planning request.', details: errorMessage }, { status: 500 });
+    }
+}
+
+// Optional: Add OPTIONS method if needed for CORS preflight requests,
+// though typically not required for same-origin API routes in Next.js.
+// export async function OPTIONS() {
+//   return new Response(null, {
+//     status: 204,
+//     headers: {
+//       'Allow': 'POST, OPTIONS',
+//     },
+//   });
+// }

--- a/ns-api-test/src/app/travel-planner/page.tsx
+++ b/ns-api-test/src/app/travel-planner/page.tsx
@@ -1,0 +1,579 @@
+"use client";
+
+import React, { useState, useEffect } from 'react'; // Added useEffect for potential future use
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger, SheetFooter, SheetClose } from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"; // For error display
+import { Loader2 } from 'lucide-react'; // For loading spinner
+import TripResultDisplay from '@/components/TripResultDisplay'; // Import the display component
+import type { Trip } from '@/components/TripResultDisplay'; // Import the Trip type
+
+// Define the state interface based on settings
+interface TravelPlannerSettings {
+  lang: string;
+  fromStation: string;
+  originUicCode: string;
+  originLat: number | null;
+  originLng: number | null;
+  originName: string;
+  toStation: string;
+  destinationUicCode: string;
+  destinationLat: number | null;
+  destinationLng: number | null;
+  destinationName: string;
+  viaStation: string;
+  viaUicCode: string;
+  viaLat: number | null;
+  viaLng: number | null;
+  originWalk: boolean;
+  originBike: boolean;
+  originCar: boolean;
+  destinationWalk: boolean;
+  destinationBike: boolean;
+  destinationCar: boolean;
+  dateTime: string; // Use string for datetime-local input
+  searchForArrival: boolean;
+  context: string;
+  addChangeTime: number | null;
+  viaWaitTime: number | null;
+  travelAssistance: boolean;
+  accessibilityEquipment1: string;
+  accessibilityEquipment2: string;
+  searchForAccessibleTrip: boolean;
+  localTrainsOnly: boolean;
+  excludeHighSpeedTrains: boolean;
+  excludeTrainsWithReservationRequired: boolean;
+  product: string;
+  discount: string;
+  travelClass: number | null; // 1 or 2
+  passing: boolean;
+  travelRequestType: string;
+  disabledTransportModalities: string[]; // Array of strings
+  firstMileModality: string;
+  lastMileModality: string;
+  entireTripModality: string;
+}
+
+// Removed duplicate interface definitions - assuming they are handled by TripResultDisplay or a shared types file
+
+const initialSettings: TravelPlannerSettings = {
+  lang: 'nl',
+  fromStation: '',
+  originUicCode: '',
+  originLat: null,
+  originLng: null,
+  originName: '',
+  toStation: '',
+  destinationUicCode: '',
+  destinationLat: null,
+  destinationLng: null,
+  destinationName: '',
+  viaStation: '',
+  viaUicCode: '',
+  viaLat: null,
+  viaLng: null,
+  originWalk: false,
+  originBike: false,
+  originCar: false,
+  destinationWalk: false,
+  destinationBike: false,
+  destinationCar: false,
+  dateTime: '',
+  searchForArrival: false,
+  context: '',
+  addChangeTime: null,
+  viaWaitTime: null,
+  travelAssistance: false,
+  accessibilityEquipment1: '',
+  accessibilityEquipment2: '',
+  searchForAccessibleTrip: false,
+  localTrainsOnly: false,
+  excludeHighSpeedTrains: false,
+  excludeTrainsWithReservationRequired: false,
+  product: '',
+  discount: '',
+  travelClass: 2, // Default to 2nd class
+  passing: false,
+  travelRequestType: '',
+  disabledTransportModalities: [],
+  firstMileModality: '',
+  lastMileModality: '',
+  entireTripModality: '',
+};
+
+// Product options from settings file
+const productOptions = [
+    "GEEN", "OVCHIPKAART_ENKELE_REIS", "OVCHIPKAART_RETOUR", "DAL_VOORDEEL",
+    "ALTIJD_VOORDEEL", "DAL_VRIJ", "WEEKEND_VRIJ", "ALTIJD_VRIJ", "BUSINESSCARD",
+    "BUSINESSCARD_DAL", "STUDENT_WEEK", "STUDENT_WEEKEND", "VDU",
+    "SAMENREISKORTING", "TRAJECT_VRIJ"
+];
+
+// Transport Modalities (example, adjust as needed based on API)
+const transportModalities = ["BUS", "FERRY", "TRAM", "METRO", "TRAIN", "SUBWAY", "SHARED_BIKE", "SHARED_CAR", "TAXI"];
+
+export default function TravelPlannerPage() {
+  const [settings, setSettings] = useState<TravelPlannerSettings>(initialSettings);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [trips, setTrips] = useState<Trip[] | null>(null); // State to hold trip results
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type } = e.target;
+    // Handle number inputs separately to store null for empty strings
+    if (type === 'number') {
+        setSettings(prev => ({
+            ...prev,
+            [name]: value === '' ? null : parseFloat(value),
+        }));
+    } else {
+        setSettings(prev => ({
+            ...prev,
+            [name]: value,
+        }));
+    }
+  };
+
+  const handleSwitchChange = (checked: boolean, name: string) => {
+     setSettings(prev => ({ ...prev, [name]: checked }));
+  };
+
+  const handleSelectChange = (value: string, name: string) => {
+    // Handle travelClass specifically to store as number or null
+    if (name === 'travelClass') {
+        setSettings(prev => ({ ...prev, [name]: value ? parseInt(value, 10) : null }));
+    } else {
+        setSettings(prev => ({ ...prev, [name]: value }));
+    }
+  };
+
+   const handleMultiSelectChange = (modality: string) => {
+    setSettings(prev => {
+      const currentModalities = prev.disabledTransportModalities;
+      if (currentModalities.includes(modality)) {
+        return { ...prev, disabledTransportModalities: currentModalities.filter(m => m !== modality) };
+      } else {
+        return { ...prev, disabledTransportModalities: [...currentModalities, modality] };
+      }
+    });
+  };
+
+  // Function to handle integer inputs specifically
+  const handleIntegerInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    const intValue = value === '' ? null : parseInt(value, 10);
+    // Allow empty string (for null) or valid non-negative integers
+    if (value === '' || (intValue !== null && !isNaN(intValue) && intValue >= 0 && Number.isInteger(intValue))) {
+        setSettings(prev => ({ ...prev, [name]: intValue }));
+    }
+    // Optionally provide feedback for invalid input (e.g., negative numbers, decimals)
+  };
+
+  const handlePlanTrip = async () => {
+    setLoading(true);
+    setError(null);
+    setTrips(null); // Clear previous results
+    setIsSettingsOpen(false); // Close the settings sheet
+
+    // Basic validation (optional, but good practice)
+    if (!settings.fromStation && !settings.originName && !settings.originUicCode && !(settings.originLat && settings.originLng)) {
+        setError("Please specify an origin station or location.");
+        setLoading(false);
+        return;
+    }
+     if (!settings.toStation && !settings.destinationName && !settings.destinationUicCode && !(settings.destinationLat && settings.destinationLng)) {
+        setError("Please specify a destination station or location.");
+        setLoading(false);
+        return;
+    }
+
+    try {
+      const response = await fetch('/api/plan-trip', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(settings),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        // Use error message from backend if available, otherwise provide a generic one
+        const errorMessage = data.error || `API request failed with status ${response.status}`;
+        const errorDetails = data.details ? ` Details: ${JSON.stringify(data.details)}` : '';
+        console.error("API Error:", errorMessage, errorDetails);
+        setError(`${errorMessage}${errorDetails}`);
+        setTrips(null);
+      } else {
+        // Assuming the API returns { trips: [...] } structure
+        if (data && Array.isArray(data.trips)) {
+            setTrips(data.trips);
+            // Optionally update context from response if needed for pagination
+            // setSettings(prev => ({ ...prev, context: data.scrollRequestForwardContext ?? prev.context }));
+        } else {
+             console.warn("API response format unexpected:", data);
+             setError("Received unexpected data format from the server.");
+             setTrips(null);
+        }
+      }
+    } catch (err) {
+      console.error('Failed to fetch trip plan:', err);
+      setError(err instanceof Error ? err.message : 'An unknown error occurred while planning the trip.');
+      setTrips(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-6">Travel Planner</h1>
+
+      {/* Main Content Area - Dynamic based on state */}
+      <div className="mb-6 p-6 border rounded-lg bg-card text-card-foreground min-h-[200px]">
+        <h2 className="text-xl font-semibold mb-4">Your Planned Trip</h2>
+        {loading && (
+          <div className="flex items-center justify-center text-muted-foreground">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+            <span>Planning your trip...</span>
+          </div>
+        )}
+        {error && !loading && (
+          <Alert variant="destructive">
+            <AlertTitle>Error Planning Trip</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        {!loading && !error && !trips && (
+          <p className="text-muted-foreground">Configure your journey using the 'Customize Trip' button and click 'Plan Trip'.</p>
+        )}
+         {!loading && !error && trips && trips.length === 0 && (
+          <p className="text-muted-foreground">No trips found matching your criteria.</p>
+        )}
+        {!loading && !error && trips && trips.length > 0 && (
+          <TripResultDisplay trips={trips} />
+        )}
+      </div>
+
+      {/* Settings Trigger Button */}
+       <Sheet open={isSettingsOpen} onOpenChange={setIsSettingsOpen}>
+        <SheetTrigger asChild>
+          <Button variant="outline">Customize Trip</Button>
+        </SheetTrigger>
+        <SheetContent className="w-[90vw] max-w-[540px] sm:w-[540px]"> {/* Responsive width */}
+          <SheetHeader>
+            <SheetTitle>Travel Settings</SheetTitle>
+          </SheetHeader>
+          {/* Use h-[calc(100vh-theme(spacing.24))] or similar for dynamic height based on header/footer */}
+          <ScrollArea className="h-[calc(100vh-120px)] pr-6"> {/* Added padding-right for scrollbar */}
+            <div className="grid gap-6 py-4"> {/* Increased gap */}
+
+              {/* --- Location Settings --- */}
+              <div>
+                <h3 className="font-semibold text-lg mb-3">Locations</h3>
+                <Separator className="mb-4"/>
+                <div className="grid gap-4">
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="fromStation" className="text-right">From Station</Label>
+                    <Input id="fromStation" name="fromStation" value={settings.fromStation} onChange={handleInputChange} className="col-span-3" placeholder="e.g., Utrecht Centraal or UT"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="originUicCode" className="text-right">Origin UIC</Label>
+                    <Input id="originUicCode" name="originUicCode" value={settings.originUicCode} onChange={handleInputChange} className="col-span-3" placeholder="UIC Code (optional)"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="originLat" className="text-right">Origin Lat</Label>
+                    <Input id="originLat" name="originLat" type="number" step="any" value={settings.originLat ?? ''} onChange={handleInputChange} className="col-span-3" placeholder="Latitude (optional)"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="originLng" className="text-right">Origin Lng</Label>
+                    <Input id="originLng" name="originLng" type="number" step="any" value={settings.originLng ?? ''} onChange={handleInputChange} className="col-span-3" placeholder="Longitude (optional)"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="originName" className="text-right">Origin Name</Label>
+                    <Input id="originName" name="originName" value={settings.originName} onChange={handleInputChange} className="col-span-3" placeholder="Custom origin name (optional)"/>
+                  </div>
+
+                  <Separator className="my-2"/>
+
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="toStation" className="text-right">To Station</Label>
+                    <Input id="toStation" name="toStation" value={settings.toStation} onChange={handleInputChange} className="col-span-3" placeholder="e.g., Amsterdam Centraal or ASD"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="destinationUicCode" className="text-right">Dest. UIC</Label>
+                    <Input id="destinationUicCode" name="destinationUicCode" value={settings.destinationUicCode} onChange={handleInputChange} className="col-span-3" placeholder="UIC Code (optional)"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="destinationLat" className="text-right">Dest. Lat</Label>
+                    <Input id="destinationLat" name="destinationLat" type="number" step="any" value={settings.destinationLat ?? ''} onChange={handleInputChange} className="col-span-3" placeholder="Latitude (optional)"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="destinationLng" className="text-right">Dest. Lng</Label>
+                    <Input id="destinationLng" name="destinationLng" type="number" step="any" value={settings.destinationLng ?? ''} onChange={handleInputChange} className="col-span-3" placeholder="Longitude (optional)"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="destinationName" className="text-right">Dest. Name</Label>
+                    <Input id="destinationName" name="destinationName" value={settings.destinationName} onChange={handleInputChange} className="col-span-3" placeholder="Custom destination name (optional)"/>
+                  </div>
+
+                  <Separator className="my-2"/>
+
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="viaStation" className="text-right">Via Station</Label>
+                    <Input id="viaStation" name="viaStation" value={settings.viaStation} onChange={handleInputChange} className="col-span-3" placeholder="Via station (optional)"/>
+                  </div>
+                  <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="viaUicCode" className="text-right">Via UIC</Label>
+                    <Input id="viaUicCode" name="viaUicCode" value={settings.viaUicCode} onChange={handleInputChange} className="col-span-3" placeholder="UIC Code (optional)"/>
+                  </div>
+                   <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="viaLat" className="text-right">Via Lat</Label>
+                    <Input id="viaLat" name="viaLat" type="number" step="any" value={settings.viaLat ?? ''} onChange={handleInputChange} className="col-span-3" placeholder="Latitude (door-to-door only)"/>
+                  </div>
+                   <div className="grid grid-cols-4 items-center gap-4">
+                    <Label htmlFor="viaLng" className="text-right">Via Lng</Label>
+                    <Input id="viaLng" name="viaLng" type="number" step="any" value={settings.viaLng ?? ''} onChange={handleInputChange} className="col-span-3" placeholder="Longitude (door-to-door only)"/>
+                  </div>
+                </div>
+              </div>
+
+              {/* --- Time & Date Settings --- */}
+              <div>
+                <h3 className="font-semibold text-lg mb-3 mt-4">Time & Date</h3>
+                <Separator className="mb-4"/>
+                <div className="grid gap-4">
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="dateTime" className="text-right">Date & Time</Label>
+                        <Input id="dateTime" name="dateTime" type="datetime-local" value={settings.dateTime} onChange={handleInputChange} className="col-span-3"/>
+                    </div>
+                    <div className="flex items-center space-x-2 col-start-2 col-span-3">
+                        <Switch id="searchForArrival" name="searchForArrival" checked={settings.searchForArrival} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'searchForArrival')} aria-label="Search for Arrival Time"/>
+                        <Label htmlFor="searchForArrival">Search for Arrival Time</Label>
+                    </div>
+                </div>
+              </div>
+
+              {/* --- Travel Options --- */}
+              <div>
+                <h3 className="font-semibold text-lg mb-3 mt-4">Travel Options</h3>
+                <Separator className="mb-4"/>
+                <div className="grid gap-4">
+                    <div className="flex items-center space-x-2">
+                        <Switch id="localTrainsOnly" name="localTrainsOnly" checked={settings.localTrainsOnly} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'localTrainsOnly')} aria-label="Local Trains Only"/>
+                        <Label htmlFor="localTrainsOnly">Local Trains Only (Sprinter/Stoptrein)</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                        <Switch id="excludeHighSpeedTrains" name="excludeHighSpeedTrains" checked={settings.excludeHighSpeedTrains} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'excludeHighSpeedTrains')} aria-label="Exclude High-Speed Trains"/>
+                        <Label htmlFor="excludeHighSpeedTrains">Exclude High-Speed Trains (incl. supplement)</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                        <Switch id="excludeTrainsWithReservationRequired" name="excludeTrainsWithReservationRequired" checked={settings.excludeTrainsWithReservationRequired} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'excludeTrainsWithReservationRequired')} aria-label="Exclude Trains Requiring Reservation"/>
+                        <Label htmlFor="excludeTrainsWithReservationRequired">Exclude Trains Requiring Reservation (e.g., Eurostar)</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                        <Switch id="passing" name="passing" checked={settings.passing} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'passing')} aria-label="Show Passing Stops"/>
+                        <Label htmlFor="passing">Show Passing Stops (non-stopping)</Label>
+                    </div>
+
+                    <div className="grid grid-cols-4 items-center gap-4 mt-2">
+                        <Label htmlFor="addChangeTime" className="text-right">Extra Transfer Time</Label>
+                        <Input id="addChangeTime" name="addChangeTime" type="number" min="0" step="1" value={settings.addChangeTime ?? ''} onChange={handleIntegerInputChange} className="col-span-3" placeholder="Minutes (optional)"/>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="viaWaitTime" className="text-right">Via Wait Time</Label>
+                        <Input id="viaWaitTime" name="viaWaitTime" type="number" min="0" step="1" value={settings.viaWaitTime ?? ''} onChange={handleIntegerInputChange} className="col-span-3" placeholder="Minutes at via station (optional)"/>
+                    </div>
+                </div>
+              </div>
+
+              {/* --- First/Last Mile --- */}
+              <div>
+                <h3 className="font-semibold text-lg mb-3 mt-4">First/Last Mile Options</h3>
+                <Separator className="mb-4"/>
+                <div className="grid gap-4">
+                    <Label className="font-medium">From Origin:</Label>
+                    <div className="flex items-center space-x-4 pl-4">
+                        <div className="flex items-center space-x-2">
+                            <Switch id="originWalk" name="originWalk" checked={settings.originWalk} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'originWalk')} aria-label="Origin Walk"/>
+                            <Label htmlFor="originWalk">Walk</Label>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                            <Switch id="originBike" name="originBike" checked={settings.originBike} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'originBike')} aria-label="Origin Bike"/>
+                            <Label htmlFor="originBike">Bike</Label>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                            <Switch id="originCar" name="originCar" checked={settings.originCar} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'originCar')} aria-label="Origin Car"/>
+                            <Label htmlFor="originCar">Car</Label>
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="firstMileModality" className="text-right">Origin Shared Modality</Label>
+                        <Input id="firstMileModality" name="firstMileModality" value={settings.firstMileModality} onChange={handleInputChange} className="col-span-3" placeholder="e.g., OV-fiets, Check (optional)"/>
+                    </div>
+
+                    <Label className="font-medium mt-2">To Destination:</Label>
+                    <div className="flex items-center space-x-4 pl-4">
+                        <div className="flex items-center space-x-2">
+                            <Switch id="destinationWalk" name="destinationWalk" checked={settings.destinationWalk} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'destinationWalk')} aria-label="Destination Walk"/>
+                            <Label htmlFor="destinationWalk">Walk</Label>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                            <Switch id="destinationBike" name="destinationBike" checked={settings.destinationBike} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'destinationBike')} aria-label="Destination Bike"/>
+                            <Label htmlFor="destinationBike">Bike</Label>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                            <Switch id="destinationCar" name="destinationCar" checked={settings.destinationCar} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'destinationCar')} aria-label="Destination Car"/>
+                            <Label htmlFor="destinationCar">Car</Label>
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="lastMileModality" className="text-right">Dest. Shared Modality</Label>
+                        <Input id="lastMileModality" name="lastMileModality" value={settings.lastMileModality} onChange={handleInputChange} className="col-span-3" placeholder="e.g., OV-fiets, Check (optional)"/>
+                    </div>
+                </div>
+              </div>
+
+              {/* --- Accessibility --- */}
+              <div>
+                <h3 className="font-semibold text-lg mb-3 mt-4">Accessibility</h3>
+                <Separator className="mb-4"/>
+                <div className="grid gap-4">
+                    <div className="flex items-center space-x-2">
+                        <Switch id="travelAssistance" name="travelAssistance" checked={settings.travelAssistance} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'travelAssistance')} aria-label="Request Travel Assistance"/>
+                        <Label htmlFor="travelAssistance">Request Travel Assistance (PAS)</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                        <Switch id="searchForAccessibleTrip" name="searchForAccessibleTrip" checked={settings.searchForAccessibleTrip} onCheckedChange={(checked: boolean) => handleSwitchChange(checked, 'searchForAccessibleTrip')} aria-label="Search for Accessible Trip"/>
+                        <Label htmlFor="searchForAccessibleTrip">Search for Accessible Trip</Label>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="accessibilityEquipment1" className="text-right">Equipment 1</Label>
+                        <Input id="accessibilityEquipment1" name="accessibilityEquipment1" value={settings.accessibilityEquipment1} onChange={handleInputChange} className="col-span-3" placeholder="e.g., SCOOTER (optional)"/>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="accessibilityEquipment2" className="text-right">Equipment 2</Label>
+                        <Input id="accessibilityEquipment2" name="accessibilityEquipment2" value={settings.accessibilityEquipment2} onChange={handleInputChange} className="col-span-3" placeholder="Optional second equipment"/>
+                    </div>
+                </div>
+              </div>
+
+              {/* --- Fare & Product --- */}
+              <div>
+                <h3 className="font-semibold text-lg mb-3 mt-4">Fare & Product</h3>
+                <Separator className="mb-4"/>
+                <div className="grid gap-4">
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="product" className="text-right">Product</Label>
+                        <Select name="product" value={settings.product} onValueChange={(value: string) => handleSelectChange(value, 'product')}>
+                        <SelectTrigger className="col-span-3">
+                            <SelectValue placeholder="Select product..." />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {/* Placeholder is handled by SelectValue */}
+                            {productOptions.map(option => (
+                            <SelectItem key={option} value={option}>{option.replace(/_/g, ' ')}</SelectItem>
+                            ))}
+                        </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="discount" className="text-right">Discount</Label>
+                        {/* TODO: Consider making this a Select if possible values are known */}
+                        <Input id="discount" name="discount" value={settings.discount} onChange={handleInputChange} className="col-span-3" placeholder="e.g., DISCOUNT_40_PERCENT (optional)"/>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="travelClass" className="text-right">Travel Class</Label>
+                        <Select name="travelClass" value={settings.travelClass?.toString() ?? ''} onValueChange={(value: string) => handleSelectChange(value, 'travelClass')}>
+                            <SelectTrigger className="col-span-3">
+                                <SelectValue placeholder="Select class..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="1">1st Class</SelectItem>
+                                <SelectItem value="2">2nd Class</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+              </div>
+
+              {/* --- Advanced/Other --- */}
+              <div>
+                <h3 className="font-semibold text-lg mb-3 mt-4">Advanced</h3>
+                <Separator className="mb-4"/>
+                <div className="grid gap-4">
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="lang" className="text-right">Language</Label>
+                        <Select name="lang" value={settings.lang} onValueChange={(value: string) => handleSelectChange(value, 'lang')}>
+                            <SelectTrigger className="col-span-3">
+                                <SelectValue placeholder="Select language..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="nl">Nederlands (nl)</SelectItem>
+                                <SelectItem value="en">English (en)</SelectItem>
+                                {/* Add other languages if supported by API */}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="context" className="text-right">Context</Label>
+                        <Input id="context" name="context" value={settings.context} onChange={handleInputChange} className="col-span-3" placeholder="For pagination (next/previous)"/>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="travelRequestType" className="text-right">Request Type</Label>
+                        <Input id="travelRequestType" name="travelRequestType" value={settings.travelRequestType} onChange={handleInputChange} className="col-span-3" placeholder="e.g., directionsOnly (optional)"/>
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="entireTripModality" className="text-right">Entire Trip Modality</Label>
+                        <Input id="entireTripModality" name="entireTripModality" value={settings.entireTripModality} onChange={handleInputChange} className="col-span-3" placeholder="Filter total trip (optional)"/>
+                    </div>
+
+                    {/* Disabled Transport Modalities */}
+                    <div>
+                        <Label className="font-medium">Exclude Transport Modalities:</Label>
+                        <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2 mt-2 pl-4">
+                        {transportModalities.map(modality => (
+                            <div key={modality} className="flex items-center space-x-2">
+                            <Checkbox
+                                id={`modality-${modality}`}
+                                checked={settings.disabledTransportModalities.includes(modality)}
+                                onCheckedChange={() => handleMultiSelectChange(modality)}
+                                aria-label={`Exclude ${modality}`}
+                            />
+                            <Label htmlFor={`modality-${modality}`} className="text-sm font-normal">
+                                {modality.replace(/_/g, ' ')}
+                            </Label>
+                            </div>
+                        ))}
+                        </div>
+                    </div>
+                </div>
+              </div>
+
+            </div> {/* End of main grid */}
+          </ScrollArea>
+          <SheetFooter className="mt-4">
+            <SheetClose asChild>
+              <Button type="button" variant="outline">Close</Button>
+            </SheetClose>
+             <Button type="button" onClick={handlePlanTrip} disabled={loading}>
+                {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                {loading ? 'Planning...' : 'Plan Trip'}
+             </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+    </div>
+  );
+}

--- a/ns-api-test/src/components/TripResultDisplay.tsx
+++ b/ns-api-test/src/components/TripResultDisplay.tsx
@@ -1,0 +1,238 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Clock, ArrowRight, TrainTrack, Shuffle, AlertCircle, CheckCircle } from 'lucide-react'; // Icons
+import { format } from 'date-fns'; // For time formatting
+
+// Re-use or import the Trip/Leg interfaces defined in page.tsx or a shared types file
+// More accurate interface based on NS API structure
+export interface StopTimeInfo {
+    name: string;
+    plannedDateTime?: string; // Use optional as actual might be preferred if available
+    actualDateTime?: string;
+    plannedTrack?: string;
+    actualTrack?: string;
+    // Add other fields like uicCode, lat, lng if needed
+}
+
+export interface ProductInfo {
+    number?: string;
+    categoryCode?: string; // e.g., IC, SPR
+    shortCategoryName?: string; // e.g., IC, SPR
+    longCategoryName?: string; // e.g., Intercity, Sprinter
+    operatorCode?: string; // e.g., NS
+    type?: string; // e.g., TRAIN
+    displayName?: string; // e.g., NS Intercity
+}
+
+export interface LegNote { // Assuming structure from previous examples
+    value: string;
+    key?: string;
+    noteType?: string; // e.g., ATTRIBUTE, UNKNOWN
+    isPresentationRequired?: boolean;
+}
+
+export interface Leg {
+    idx: string; // Leg index
+    name?: string; // Train name like "IC 3071"
+    direction?: string;
+    origin: StopTimeInfo;
+    destination: StopTimeInfo;
+    product?: ProductInfo;
+    notes?: LegNote[]; // For leg-specific remarks
+    cancelled?: boolean;
+    changePossible?: boolean;
+    alternativeTransport?: boolean;
+    // Add crowdForecast, punctuality, stops array etc. if needed
+}
+
+// More accurate Trip interface
+export interface TripNote { // Assuming structure from previous examples
+    message: string;
+    type?: string; // e.g., INFO, WARNING
+}
+export interface LabelListItem { // For things like supplements
+    label: string;
+    stickerType?: string;
+}
+
+export interface Trip {
+    uid: string; // Unique identifier for the trip option
+    plannedDurationInMinutes: number;
+    actualDurationInMinutes?: number;
+    transfers: number;
+    status: string; // e.g., NORMAL, CANCELLED, DISRUPTION, ALTERED
+    legs: Leg[];
+    messages?: TripNote[]; // Renamed from notes for clarity based on API structure
+    labelListItems?: LabelListItem[]; // For supplements etc.
+    // Add crowdForecast, optimal, fare info etc. if needed
+}
+
+interface TripResultDisplayProps {
+    trips: Trip[];
+}
+
+// Helper to format duration
+const formatDuration = (minutes: number): string => {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    let durationString = '';
+    if (hours > 0) {
+        durationString += `${hours}h `;
+    }
+    durationString += `${mins}m`;
+    return durationString;
+};
+
+// Helper to format time string (assuming ISO 8601 format from API)
+const formatTime = (isoString: string): string => {
+    try {
+        return format(new Date(isoString), 'HH:mm');
+    } catch (e) {
+        console.error("Error formatting time:", isoString, e);
+        return "Invalid Time";
+    }
+};
+
+// Helper to get status icon and color
+const getStatusInfo = (status: string): { icon: React.ReactNode; color: string } => {
+    switch (status?.toUpperCase()) {
+        case 'CANCELLED':
+            return { icon: <AlertCircle className="h-4 w-4 text-red-600" />, color: 'text-red-600' };
+        case 'DISRUPTION':
+        case 'ALTERED': // Treat altered also as a disruption indicator
+            return { icon: <AlertCircle className="h-4 w-4 text-orange-500" />, color: 'text-orange-500' };
+        case 'NORMAL':
+            return { icon: <CheckCircle className="h-4 w-4 text-green-600" />, color: 'text-green-600' };
+        default:
+            return { icon: null, color: 'text-muted-foreground' }; // Default or unknown status
+    }
+};
+
+const TripResultDisplay: React.FC<TripResultDisplayProps> = ({ trips }) => {
+    if (!trips || trips.length === 0) {
+        return <p className="text-muted-foreground">No trip results to display.</p>;
+    }
+
+    return (
+        <div className="space-y-4">
+            {trips.map((trip, index) => {
+                const { icon: statusIcon, color: statusColor } = getStatusInfo(trip.status);
+                // Use plannedDateTime, fallback to actualDateTime if needed/available
+                const overallStartTime = trip.legs[0]?.origin?.plannedDateTime || trip.legs[0]?.origin?.actualDateTime;
+                const overallEndTime = trip.legs[trip.legs.length - 1]?.destination?.plannedDateTime || trip.legs[trip.legs.length - 1]?.destination?.actualDateTime;
+                const overallOriginName = trip.legs[0]?.origin?.name;
+                const overallDestinationName = trip.legs[trip.legs.length - 1]?.destination?.name;
+
+                return (
+                    <Card key={trip.uid || index} className="overflow-hidden">
+                        <CardHeader className="pb-2">
+                            <div className="flex justify-between items-start gap-2">
+                                <div>
+                                    {/* Corrected Structure: Title and Description are siblings */}
+                                    <CardTitle className="text-lg">
+                                        {overallOriginName || '?'} <ArrowRight className="inline h-4 w-4 mx-1" /> {overallDestinationName || '?'}
+                                    </CardTitle>
+                                    <CardDescription className="text-sm">
+                                        {overallStartTime ? formatTime(overallStartTime) : '?'} - {overallEndTime ? formatTime(overallEndTime) : '?'}
+                                    </CardDescription>
+                                    {/* Div for duration/transfers/status is also a sibling */}
+                                    <div className="flex items-center gap-3 text-sm mt-1">
+                                        <span className="flex items-center gap-1" title="Duration">
+                                            <Clock className="h-3.5 w-3.5" />
+                                            {formatDuration(trip.actualDurationInMinutes ?? trip.plannedDurationInMinutes)}
+                                        </span>
+                                        <span className="flex items-center gap-1" title="Transfers">
+                                            <Shuffle className="h-3.5 w-3.5" />
+                                            {trip.transfers} Transfer{trip.transfers !== 1 ? 's' : ''}
+                                        </span>
+                                        {statusIcon && (
+                                            <span className={`flex items-center gap-1 ${statusColor}`} title={`Status: ${trip.status}`}>
+                                                {statusIcon}
+                                                {trip.status}
+                                            </span>
+                                        )}
+                                    </div>
+                                    {/* Display trip-level labels (e.g., supplements) */}
+                                    {trip.labelListItems && trip.labelListItems.length > 0 && (
+                                        <div className="mt-1 text-xs space-x-1">
+                                            {trip.labelListItems.map((label, lblIdx) => (
+                                                <span key={lblIdx} className="inline-block bg-muted text-muted-foreground px-1.5 py-0.5 rounded-sm">{label.label}</span>
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+                                {/* Optional: Add price or other summary info here */}
+                            </div>
+                             {/* Display trip-level notes/messages */}
+                             {/* Display trip-level messages */}
+                             {trip.messages && trip.messages.length > 0 && (
+                                <div className="mt-2 text-xs space-y-1">
+                                    {trip.messages.map((msg, msgIdx) => (
+                                        <p key={msgIdx} className={`flex items-center gap-1 ${msg.type === 'WARNING' ? 'text-orange-600' : msg.type === 'ERROR' ? 'text-red-600' : 'text-muted-foreground'}`}>
+                                            {msg.type === 'WARNING' || msg.type === 'ERROR' ? <AlertCircle className="h-3 w-3" /> : null}
+                                            {msg.message} {/* Use message field */}
+                                        </p>
+                                    ))}
+                                </div>
+                            )}
+                        </CardHeader>
+                        <CardContent className="pt-2">
+                            <Separator className="mb-3" />
+                            <div className="space-y-3">
+                                {trip.legs.map((leg, legIndex) => (
+                                    <div key={legIndex} className={`relative pl-6 ${leg.cancelled ? 'opacity-50 line-through' : ''}`}>
+                                        {/* Timeline Dot */}
+                                        <div className={`absolute left-0 top-1 h-3 w-3 rounded-full ${leg.cancelled ? 'bg-red-400' : 'bg-primary'}`}></div>
+                                        {/* Timeline Line (except for last leg) */}
+                                        {legIndex < trip.legs.length - 1 && (
+                                            <div className={`absolute left-[5px] top-[18px] h-[calc(100%-5px)] w-[2px] ${leg.cancelled ? 'bg-red-200' : 'bg-primary/30'}`}></div>
+                                        )}
+
+                                        <div className="flex justify-between items-center mb-1">
+                                            <span className="font-medium">{formatTime(leg.origin.plannedDateTime || leg.origin.actualDateTime || '')} - {leg.origin.name}</span>
+                                            {(leg.origin.actualTrack || leg.origin.plannedTrack) && <span className="text-xs text-muted-foreground flex items-center gap-1"><TrainTrack className="h-3 w-3" /> Spoor {leg.origin.actualTrack || leg.origin.plannedTrack}</span>}
+                                        </div>
+                                        <div className="text-sm text-muted-foreground mb-1 ml-1 flex items-center gap-2">
+                                            <ArrowRight className="h-3 w-3" />
+                                            <span>{leg.product?.shortCategoryName || leg.product?.type || 'Unknown'} {leg.product?.number || leg.name || ''}</span> { /* Display train name if product number missing */}
+                                            {leg.direction && <span className="text-xs italic ml-1">({leg.direction})</span>}
+                                            {leg.cancelled && <span className="text-red-600 font-semibold">(Cancelled)</span>}
+                                            {leg.alternativeTransport && <span className="text-orange-500 font-semibold">(Alternative Transport)</span>}
+                                        </div>
+                                         {/* Display leg-level notes/messages */}
+                                         {leg.notes && leg.notes.length > 0 && (
+                                            <div className="ml-1 mt-1 text-xs space-y-0.5">
+                                                {/* Filter notes that should be presented */}
+                                                {leg.notes?.filter(note => note.isPresentationRequired !== false).map((note, noteIdx) => (
+                                                    <p key={noteIdx} className={`flex items-center gap-1 ${note.noteType === 'WARNING' ? 'text-orange-600' : note.noteType === 'ERROR' ? 'text-red-600' : 'text-muted-foreground'}`}>
+                                                        {note.noteType === 'WARNING' || note.noteType === 'ERROR' ? <AlertCircle className="h-3 w-3" /> : null}
+                                                        {note.value}
+                                                    </p>
+                                                ))}
+                                            </div>
+                                        )}
+                                        <div className="flex justify-between items-center mt-1">
+                                            <span className="font-medium">{formatTime(leg.destination.plannedDateTime || leg.destination.actualDateTime || '')} - {leg.destination.name}</span>
+                                            {(leg.destination.actualTrack || leg.destination.plannedTrack) && <span className="text-xs text-muted-foreground flex items-center gap-1"><TrainTrack className="h-3 w-3" /> Spoor {leg.destination.actualTrack || leg.destination.plannedTrack}</span>}
+                                        </div>
+                                        {/* Add transfer info if not the last leg */}
+                                        {legIndex < trip.legs.length - 1 && leg.changePossible !== false && (
+                                            <Separator className="my-2" />
+                                            // Optional: Add transfer time indication here if available in API data
+                                        )}
+                                         {legIndex < trip.legs.length - 1 && leg.changePossible === false && (
+                                            <div className="my-2 text-sm text-orange-600 font-medium flex items-center gap-1"><AlertCircle className="h-4 w-4" /> Short transfer - Not guaranteed</div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                );
+            })}
+        </div>
+    );
+};
+
+export default TripResultDisplay;

--- a/ns-api-test/src/components/ui/alert.tsx
+++ b/ns-api-test/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/ns-api-test/src/components/ui/button.tsx
+++ b/ns-api-test/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/ns-api-test/src/components/ui/card.tsx
+++ b/ns-api-test/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/ns-api-test/src/components/ui/checkbox.tsx
+++ b/ns-api-test/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/ns-api-test/src/components/ui/input.tsx
+++ b/ns-api-test/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/ns-api-test/src/components/ui/label.tsx
+++ b/ns-api-test/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/ns-api-test/src/components/ui/scroll-area.tsx
+++ b/ns-api-test/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/ns-api-test/src/components/ui/select.tsx
+++ b/ns-api-test/src/components/ui/select.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/ns-api-test/src/components/ui/separator.tsx
+++ b/ns-api-test/src/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/ns-api-test/src/components/ui/sheet.tsx
+++ b/ns-api-test/src/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/ns-api-test/src/components/ui/switch.tsx
+++ b/ns-api-test/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/ns-api-test/travel_planner_output.txt
+++ b/ns-api-test/travel_planner_output.txt
@@ -1,0 +1,6006 @@
+{
+    "source": "HARP",
+    "trips": [{
+        "idx": 0,
+        "uid": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T18:44:00+02:00|plannedArrivalTime=2025-04-05T20:08:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=1040263288",
+        "ctxRecon": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T18:44:00+02:00|plannedArrivalTime=2025-04-05T20:08:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=1040263288",
+        "sourceCtxRecon": "¶HKI¶T$A=1@O=Alkmaar@L=1101021@a=128@$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$202504051844$202504051915$IC 3071 $$1$$$$$$§W$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$A=1@O=Amsterdam Sloterdijk@L=1100933@a=128@$202504051915$202504051920$$$1$$$$$$§T$A=1@O=Amsterdam Sloterdijk@L=1100933@a=128@$A=1@O=Schiphol Airport@L=1100911@a=128@$202504051925$202504051935$SPR 8273$$1$$$$$$§W$A=1@O=Schiphol Airport@L=1100911@a=128@$A=1@O=Schiphol Airport@L=1100725@a=128@$202504051935$202504051939$$$1$$$$$$§T$A=1@O=Schiphol Airport@L=1100725@a=128@$A=1@O=Rotterdam Centraal@L=1100729@a=128@$202504051942$202504052008$ICD 2466$$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#16481#AM2#0#RT#31#¶KCC¶#VE#0#ERG#5#HIN#0#ECK#11204|11204|11288|11288|0|0|65861|11195|1|0|2|0|0|-2147483648#¶KRCC¶#VE#1#MRTF#",
+        "plannedDurationInMinutes": 84,
+        "actualDurationInMinutes": 84,
+        "transfers": 2,
+        "status": "NORMAL",
+        "messages": [],
+        "legs": [{
+            "idx": "0",
+            "name": "IC 3071",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Nijmegen",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539273#TA#0#DA#50425#1S#1101028#1T#1804#LS#1101149#LT#2047#PU#784#RT#1#CA#IC#ZE#3071#ZB#IC 3071 #PC#1#FR#1101028#FT#1804#TO#1101149#TT#2047#",
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T18:44:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T18:44:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "checkinStatus": "CHECKIN",
+                "notes": []
+            },
+            "destination": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:15:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T19:15:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "exitSide": "RIGHT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3071",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Nijmegen",
+                        "shortValue": "to Nijmegen",
+                        "accessibilityValue": "to Nijmegen",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "3 intermediate stops",
+                        "shortValue": "3 intermediate stops",
+                        "accessibilityValue": "3 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "stops": [{
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "name": "Alkmaar",
+                "lat": 52.6377792358398,
+                "lng": 4.73972225189209,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T18:44:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:44:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "departureDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400309",
+                "uicCdCode": "118400309",
+                "name": "Heiloo",
+                "lat": 52.5994453430176,
+                "lng": 4.70055532455444,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T18:49:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:49:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T18:49:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T18:49:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400151",
+                "uicCdCode": "118400151",
+                "name": "Castricum",
+                "lat": 52.5458335876465,
+                "lng": 4.65861129760742,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedDepartureDateTime": "2025-04-05T18:55:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:55:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T18:55:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T18:55:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400731",
+                "uicCdCode": "118400731",
+                "name": "Zaandam",
+                "lat": 52.4388885498047,
+                "lng": 4.81361103057861,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T19:08:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T19:08:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:08:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:08:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedArrivalDateTime": "2025-04-05T19:15:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:15:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "punctuality": 100.0,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539273#TA#0#DA#50425#1S#1101028#1T#1804#LS#1101149#LT#2047#PU#784#RT#1#CA#IC#ZE#3071#ZB#IC 3071 #PC#1#FR#1101028#FT#1804#TO#1101149#TT#2047#&train=3071&datetime=2025-04-05T18:44:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 31,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "31 min.",
+                "accessibilityValue": "31 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 5
+        }, {
+            "idx": "1",
+            "name": "SPR 8273",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Hoofddorp",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#546252#TA#6#DA#50425#1S#1100807#1T#1919#LS#1101153#LT#1942#PU#784#RT#1#CA#SPR#ZE#8273#ZB#SPR 8273#PC#3#FR#1100807#FT#1919#TO#1101153#TT#1942#",
+            "origin": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:25:00+0200",
+                "plannedTrack": "11",
+                "actualTrack": "11",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Schiphol Airport ✈",
+                "lng": 4.76194429397583,
+                "lat": 52.3094444274902,
+                "countryCode": "NL",
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "stationCode": "SHL",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:35:00+0200",
+                "plannedTrack": "4",
+                "actualTrack": "4",
+                "exitSide": "LEFT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "8273",
+                "categoryCode": "SPR",
+                "shortCategoryName": "SPR",
+                "longCategoryName": "Sprinter",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Sprinter",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Sprinter",
+                        "shortValue": "NS Sprinter",
+                        "accessibilityValue": "NS Sprinter",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Hoofddorp",
+                        "shortValue": "to Hoofddorp",
+                        "accessibilityValue": "to Hoofddorp",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "1 intermediate stop",
+                        "shortValue": "1 intermediate stop",
+                        "accessibilityValue": "1 intermediate stop",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "transferMessages": [{
+                "message": "10 min. transfer time",
+                "accessibilityMessage": "10 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:25:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "11",
+                "plannedDepartureTrack": "11",
+                "plannedArrivalTrack": "11",
+                "actualArrivalTrack": "11",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400079",
+                "uicCdCode": "118400079",
+                "name": "Amsterdam Lelylaan",
+                "lat": 52.3577766418457,
+                "lng": 4.83388900756836,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T19:29:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:29:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "1",
+                "plannedDepartureTrack": "1",
+                "plannedArrivalTrack": "1",
+                "actualArrivalTrack": "1",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "name": "Schiphol Airport",
+                "lat": 52.3094444274902,
+                "lng": 4.76194429397583,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedArrivalDateTime": "2025-04-05T19:35:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 4,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#546252#TA#6#DA#50425#1S#1100807#1T#1919#LS#1101153#LT#1942#PU#784#RT#1#CA#SPR#ZE#8273#ZB#SPR 8273#PC#3#FR#1100807#FT#1919#TO#1101153#TT#1942#&train=8273&datetime=2025-04-05T19:25:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 10,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "10 min.",
+                "accessibilityValue": "10 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 4
+        }, {
+            "idx": "2",
+            "name": "ICD 2466",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Rotterdam Centraal",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#537761#TA#0#DA#50425#1S#1100988#1T#1852#LS#1100729#LT#2008#PU#784#RT#1#CA#ICD#ZE#2466#ZB#ICD 2466#PC#1#FR#1100988#FT#1852#TO#1100729#TT#2008#",
+            "origin": {
+                "name": "Schiphol Airport ✈",
+                "lng": 4.76194429397583,
+                "lat": 52.3094444274902,
+                "countryCode": "NL",
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "stationCode": "SHL",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:42:00+0200",
+                "plannedTrack": "5-6",
+                "actualTrack": "5-6",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:08:00+0200",
+                "plannedTrack": "11",
+                "actualTrack": "11",
+                "exitSide": "LEFT",
+                "checkinStatus": "CHECKOUT",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "2466",
+                "categoryCode": "ICD",
+                "shortCategoryName": "ICD",
+                "longCategoryName": "Intercity direct",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity direct",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity direct",
+                        "shortValue": "NS Intercity direct",
+                        "accessibilityValue": "NS Intercity direct",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Rotterdam Centraal",
+                        "shortValue": "to Rotterdam Centraal",
+                        "accessibilityValue": "to Rotterdam Centraal",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "No intermediate stops",
+                        "shortValue": "No intermediate stops",
+                        "accessibilityValue": "No intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "Supplement",
+                        "shortValue": "Supplement",
+                        "accessibilityValue": "Supplement",
+                        "key": "PRODUCT_SUPPLEMENT",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-warning-contrast",
+                            "type": "warning"
+                        }
+                    }]
+                ]
+            },
+            "notes": [{
+                "value": "Supplement",
+                "shortValue": "Supplement",
+                "accessibilityValue": "Supplement",
+                "key": "ZA",
+                "noteType": "ATTRIBUTE",
+                "isPresentationRequired": true
+            }, {
+                "value": "300",
+                "key": "T",
+                "noteType": "TICKET",
+                "routeIdxFrom": 0,
+                "routeIdxTo": 2,
+                "link": {
+                    "uri": "/api/v1/catalogue/intercity-direct"
+                },
+                "isPresentationRequired": false
+            }],
+            "transferMessages": [{
+                "message": "7 min. transfer time",
+                "accessibilityMessage": "7 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "name": "Schiphol Airport",
+                "lat": 52.3094444274902,
+                "lng": 4.76194429397583,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:42:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5-6",
+                "plannedDepartureTrack": "5-6",
+                "plannedArrivalTrack": "5-6",
+                "actualArrivalTrack": "5-6",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "name": "Rotterdam Centraal",
+                "lat": 51.9249992370605,
+                "lng": 4.46888875961304,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedArrivalDateTime": "2025-04-05T20:08:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "11",
+                "plannedDepartureTrack": "11",
+                "plannedArrivalTrack": "11",
+                "actualArrivalTrack": "11",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 16,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#537761#TA#0#DA#50425#1S#1100988#1T#1852#LS#1100729#LT#2008#PU#784#RT#1#CA#ICD#ZE#2466#ZB#ICD 2466#PC#1#FR#1100988#FT#1852#TO#1100729#TT#2008#&train=2466&datetime=2025-04-05T19:42:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 26,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "26 min.",
+                "accessibilityValue": "26 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": []
+        }],
+        "checksum": "5bf40e44_3",
+        "crowdForecast": "LOW",
+        "punctuality": 100.0,
+        "optimal": false,
+        "fareRoute": {
+            "routeId": "=Lh0XlJWEeA==",
+            "origin": {
+                "varCode": 50,
+                "name": "Alkmaar"
+            },
+            "destination": {
+                "varCode": 530,
+                "name": "Rotterdam Centraal"
+            }
+        },
+        "fares": [{
+            "priceInCents": 3672,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2938,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 1728,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 2203,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 1296,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 7344,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 4320,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 5876,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 3456,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 4406,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 2592,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 63870,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 37570,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 766440,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 450840,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }],
+        "fareLegs": [{
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION"
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION"
+            },
+            "operator": "NS",
+            "productTypes": ["TRAIN"],
+            "fares": [{
+                "priceInCents": 2160,
+                "priceInCentsExcludingSupplement": 2160,
+                "supplementInCents": 0,
+                "buyableTicketSupplementPriceInCents": 0,
+                "product": "OVCHIPKAART_ENKELE_REIS",
+                "travelClass": "SECOND_CLASS",
+                "discountType": "NO_DISCOUNT"
+            }],
+            "travelDate": "2025-04-05"
+        }],
+        "productFare": {
+            "priceInCents": 2460,
+            "priceInCentsExcludingSupplement": 2160,
+            "supplementInCents": 300,
+            "buyableTicketPriceInCents": 2460,
+            "buyableTicketPriceInCentsExcludingSupplement": 2160,
+            "buyableTicketSupplementPriceInCents": 300,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        },
+        "fareOptions": {
+            "isInternationalBookable": false,
+            "isInternational": false,
+            "isEticketBuyable": true,
+            "isPossibleWithOvChipkaart": true,
+            "isTotalPriceUnknown": false,
+            "supplementsBasedOnSelectedFare": [{
+                "supplementPriceInCents": 300,
+                "fromUICCode": "8400561",
+                "toUICCode": "8400530",
+                "link": {
+                    "uri": "/api/v1/catalogue/intercity-direct"
+                },
+                "supplementType": "ICD"
+            }]
+        },
+        "nsiLink": {
+            "url": "https://www.nsinternational.com/en/traintickets-v3/#/search/AMR/RTD/20250405/1844/2008?stationType=domestic&cookieConsent=false",
+            "showInternationalBanner": false
+        },
+        "type": "NS",
+        "shareUrl": {
+            "uri": "https://www.ns.nl/rpx?ctx=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T18%3A44%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A08%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D1040263288"
+        },
+        "realtime": true,
+        "routeId": "=Lh0XlJWEeA==",
+        "registerJourney": {
+            "url": "https://treinwijzer.ns.nl/idp/login?ctxRecon=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T18%3A44%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A08%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D1040263288&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "searchUrl": "https://treinwijzer.ns.nl/idp/login?search=true&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "status": "REGISTRATION_POSSIBLE",
+            "bicycleReservationRequired": false
+        },
+        "modalityListItems": [{
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Sprinter",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "11",
+            "accessibilityName": "Sprinter"
+        }, {
+            "name": "Intercity direct",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5-6",
+            "accessibilityName": "Intercity direct"
+        }],
+        "labelListItems": [{
+            "label": "€ 3.00 supplement",
+            "stickerType": "default"
+        }]
+    }, {
+        "idx": 1,
+        "uid": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T18:44:00+02:00|plannedArrivalTime=2025-04-05T20:35:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=1429093491",
+        "ctxRecon": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T18:44:00+02:00|plannedArrivalTime=2025-04-05T20:35:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=1429093491",
+        "sourceCtxRecon": "¶HKI¶T$A=1@O=Alkmaar@L=1101021@a=128@$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$202504051844$202504051915$IC 3071 $$1$$$$$$§W$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$A=1@O=Amsterdam Sloterdijk@L=1101087@a=128@$202504051915$202504051919$$$1$$$$$$§T$A=1@O=Amsterdam Sloterdijk@L=1101087@a=128@$A=1@O=Leiden Centraal@L=1100917@a=128@$202504051925$202504051956$IC 2177 $$1$$$$$$§W$A=1@O=Leiden Centraal@L=1100917@a=128@$A=1@O=Leiden Centraal@L=1100721@a=128@$202504051956$202504051958$$$1$$$$$$§T$A=1@O=Leiden Centraal@L=1100721@a=128@$A=1@O=Rotterdam Centraal@L=1100724@a=128@$202504052002$202504052035$IC 3566 $$3$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#16481#AM2#0#RT#31#¶KCC¶#VE#0#ERG#45317#HIN#0#ECK#11204|11204|11288|11315|0|0|65861|11195|2|0|8|0|0|-2147483648#¶KRCC¶#VE#1#MRTF#",
+        "plannedDurationInMinutes": 111,
+        "actualDurationInMinutes": 111,
+        "transfers": 2,
+        "status": "NORMAL",
+        "messages": [],
+        "legs": [{
+            "idx": "0",
+            "name": "IC 3071",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Nijmegen",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539273#TA#0#DA#50425#1S#1101028#1T#1804#LS#1101149#LT#2047#PU#784#RT#1#CA#IC#ZE#3071#ZB#IC 3071 #PC#1#FR#1101028#FT#1804#TO#1101149#TT#2047#",
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T18:44:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T18:44:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "checkinStatus": "CHECKIN",
+                "notes": []
+            },
+            "destination": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:15:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T19:15:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "exitSide": "RIGHT",
+                "checkinStatus": "DETOUR",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3071",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Nijmegen",
+                        "shortValue": "to Nijmegen",
+                        "accessibilityValue": "to Nijmegen",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "3 intermediate stops",
+                        "shortValue": "3 intermediate stops",
+                        "accessibilityValue": "3 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "notes": [{
+                "value": "Avoid extra costs: transfer via the station hall",
+                "accessibilityValue": "Avoid extra costs: transfer via the station hall",
+                "key": "CheckInOutText",
+                "noteType": "UNKNOWN",
+                "isPresentationRequired": false
+            }],
+            "stops": [{
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "name": "Alkmaar",
+                "lat": 52.6377792358398,
+                "lng": 4.73972225189209,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T18:44:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:44:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "departureDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400309",
+                "uicCdCode": "118400309",
+                "name": "Heiloo",
+                "lat": 52.5994453430176,
+                "lng": 4.70055532455444,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T18:49:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:49:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T18:49:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T18:49:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400151",
+                "uicCdCode": "118400151",
+                "name": "Castricum",
+                "lat": 52.5458335876465,
+                "lng": 4.65861129760742,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedDepartureDateTime": "2025-04-05T18:55:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:55:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T18:55:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T18:55:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400731",
+                "uicCdCode": "118400731",
+                "name": "Zaandam",
+                "lat": 52.4388885498047,
+                "lng": 4.81361103057861,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T19:08:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T19:08:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:08:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:08:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedArrivalDateTime": "2025-04-05T19:15:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:15:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "punctuality": 100.0,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539273#TA#0#DA#50425#1S#1101028#1T#1804#LS#1101149#LT#2047#PU#784#RT#1#CA#IC#ZE#3071#ZB#IC 3071 #PC#1#FR#1101028#FT#1804#TO#1101149#TT#2047#&train=3071&datetime=2025-04-05T18:44:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 31,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "31 min.",
+                "accessibilityValue": "31 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 4
+        }, {
+            "idx": "1",
+            "name": "IC 2177",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Leiden Centraal",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#1040#TA#0#DA#50425#1S#1100916#1T#1920#LS#1100917#LT#1956#PU#784#RT#1#CA#IC#ZE#2177#ZB#IC 2177 #PC#1#FR#1100916#FT#1920#TO#1100917#TT#1956#",
+            "origin": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:25:00+0200",
+                "plannedTrack": "7",
+                "actualTrack": "7",
+                "checkinStatus": "DETOUR",
+                "notes": []
+            },
+            "destination": {
+                "name": "Leiden Centraal",
+                "lng": 4.48166656494141,
+                "lat": 52.1661109924316,
+                "countryCode": "NL",
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "stationCode": "LEDN",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:56:00+0200",
+                "plannedTrack": "9b",
+                "actualTrack": "9b",
+                "exitSide": "LEFT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "2177",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Leiden Centraal",
+                        "shortValue": "to Leiden Centraal",
+                        "accessibilityValue": "to Leiden Centraal",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "2 intermediate stops",
+                        "shortValue": "2 intermediate stops",
+                        "accessibilityValue": "2 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "transferMessages": [{
+                "message": "10 min. transfer time",
+                "accessibilityMessage": "10 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }, {
+                "message": "Avoid extra costs: transfer via the station hall",
+                "accessibilityMessage": "Avoid extra costs: transfer via the station hall",
+                "type": "SPECIAL",
+                "messageNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "pink-500",
+                    "icon": "ov-chipkaart"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:25:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "7",
+                "plannedDepartureTrack": "7",
+                "plannedArrivalTrack": "7",
+                "actualArrivalTrack": "7",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400285",
+                "uicCdCode": "118400285",
+                "name": "Haarlem",
+                "lat": 52.3877792358398,
+                "lng": 4.63833332061768,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 3,
+                "plannedDepartureDateTime": "2025-04-05T19:37:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:35:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "6",
+                "plannedDepartureTrack": "6",
+                "plannedArrivalTrack": "6",
+                "actualArrivalTrack": "6",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400302",
+                "uicCdCode": "118400302",
+                "name": "Heemstede-Aerdenhout",
+                "lat": 52.3591651916504,
+                "lng": 4.60666656494141,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 4,
+                "plannedDepartureDateTime": "2025-04-05T19:42:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:42:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "name": "Leiden Centraal",
+                "lat": 52.1661109924316,
+                "lng": 4.48166656494141,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 7,
+                "plannedArrivalDateTime": "2025-04-05T19:56:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "9b",
+                "plannedDepartureTrack": "9b",
+                "plannedArrivalTrack": "9b",
+                "actualArrivalTrack": "9b",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "MEDIUM",
+            "bicycleSpotCount": 6,
+            "punctuality": 90.9,
+            "crossPlatformTransfer": true,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#1040#TA#0#DA#50425#1S#1100916#1T#1920#LS#1100917#LT#1956#PU#784#RT#1#CA#IC#ZE#2177#ZB#IC 2177 #PC#1#FR#1100916#FT#1920#TO#1100917#TT#1956#&train=2177&datetime=2025-04-05T19:25:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 31,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "31 min.",
+                "accessibilityValue": "31 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 2
+        }, {
+            "idx": "2",
+            "name": "IC 3566",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Dordrecht",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#620194#TA#0#DA#50425#1S#1100958#1T#1733#LS#1101093#LT#2052#PU#784#RT#3#CA#IC#ZE#3566#ZB#IC 3566 #PC#1#FR#1100958#FT#1733#TO#1101093#TT#2052#",
+            "origin": {
+                "name": "Leiden Centraal",
+                "lng": 4.48166656494141,
+                "lat": 52.1661109924316,
+                "countryCode": "NL",
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "stationCode": "LEDN",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:02:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T20:02:00+0200",
+                "plannedTrack": "8b",
+                "actualTrack": "8b",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:35:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T20:35:00+0200",
+                "plannedTrack": "7",
+                "actualTrack": "7",
+                "exitSide": "RIGHT",
+                "checkinStatus": "CHECKOUT",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3566",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Dordrecht",
+                        "shortValue": "to Dordrecht",
+                        "accessibilityValue": "to Dordrecht",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "4 intermediate stops",
+                        "shortValue": "4 intermediate stops",
+                        "accessibilityValue": "4 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "transferMessages": [{
+                "message": "Transfer at same platform",
+                "accessibilityMessage": "Transfer at same platform",
+                "type": "CROSS_PLATFORM",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "name": "Leiden Centraal",
+                "lat": 52.1661109924316,
+                "lng": 4.48166656494141,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T20:02:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:02:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "8b",
+                "plannedDepartureTrack": "8b",
+                "plannedArrivalTrack": "8b",
+                "actualArrivalTrack": "8b",
+                "departureDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400380",
+                "uicCdCode": "118400380",
+                "name": "Den Haag Laan v NOI",
+                "lat": 52.0786094665527,
+                "lng": 4.34277772903442,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 4,
+                "plannedDepartureDateTime": "2025-04-05T20:11:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:11:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:10:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:10:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400280",
+                "uicCdCode": "118400280",
+                "name": "Den Haag HS",
+                "lat": 52.0697212219238,
+                "lng": 4.32250022888184,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 5,
+                "plannedDepartureDateTime": "2025-04-05T20:16:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:16:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:14:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:14:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400170",
+                "uicCdCode": "118400170",
+                "name": "Delft",
+                "lat": 52.0066680908203,
+                "lng": 4.35638904571533,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T20:22:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:22:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:22:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:22:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400553",
+                "uicCdCode": "118400553",
+                "name": "Schiedam Centrum",
+                "lat": 51.9212438128032,
+                "lng": 4.4089937210083,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 10,
+                "plannedDepartureDateTime": "2025-04-05T20:30:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:30:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:30:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:30:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "name": "Rotterdam Centraal",
+                "lat": 51.9249992370605,
+                "lng": 4.46888875961304,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 11,
+                "plannedArrivalDateTime": "2025-04-05T20:35:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:35:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "7",
+                "plannedDepartureTrack": "7",
+                "plannedArrivalTrack": "7",
+                "actualArrivalTrack": "7",
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "HIGH",
+            "bicycleSpotCount": 6,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#620194#TA#0#DA#50425#1S#1100958#1T#1733#LS#1101093#LT#2052#PU#784#RT#3#CA#IC#ZE#3566#ZB#IC 3566 #PC#1#FR#1100958#FT#1733#TO#1101093#TT#2052#&train=3566&datetime=2025-04-05T20:02:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 33,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "33 min.",
+                "accessibilityValue": "33 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": []
+        }],
+        "checksum": "6c566f64_3",
+        "crowdForecast": "HIGH",
+        "punctuality": 90.9,
+        "optimal": false,
+        "fareRoute": {
+            "routeId": "=Lh0XlJWEeA==",
+            "origin": {
+                "varCode": 50,
+                "name": "Alkmaar"
+            },
+            "destination": {
+                "varCode": 530,
+                "name": "Rotterdam Centraal"
+            }
+        },
+        "fares": [{
+            "priceInCents": 3672,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2938,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 1728,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 2203,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 1296,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 7344,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 4320,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 5876,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 3456,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 4406,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 2592,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 63870,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 37570,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 766440,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 450840,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }],
+        "fareLegs": [{
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION"
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION"
+            },
+            "operator": "NS",
+            "productTypes": ["TRAIN"],
+            "fares": [{
+                "priceInCents": 2160,
+                "priceInCentsExcludingSupplement": 2160,
+                "supplementInCents": 0,
+                "buyableTicketSupplementPriceInCents": 0,
+                "product": "OVCHIPKAART_ENKELE_REIS",
+                "travelClass": "SECOND_CLASS",
+                "discountType": "NO_DISCOUNT"
+            }],
+            "travelDate": "2025-04-05"
+        }],
+        "productFare": {
+            "priceInCents": 2160,
+            "priceInCentsExcludingSupplement": 2160,
+            "buyableTicketPriceInCents": 2160,
+            "buyableTicketPriceInCentsExcludingSupplement": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        },
+        "fareOptions": {
+            "isInternationalBookable": false,
+            "isInternational": false,
+            "isEticketBuyable": true,
+            "isPossibleWithOvChipkaart": true,
+            "isTotalPriceUnknown": false
+        },
+        "nsiLink": {
+            "url": "https://www.nsinternational.com/en/traintickets-v3/#/search/AMR/RTD/20250405/1844/2035?stationType=domestic&cookieConsent=false",
+            "showInternationalBanner": false
+        },
+        "type": "NS",
+        "shareUrl": {
+            "uri": "https://www.ns.nl/rpx?ctx=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T18%3A44%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A35%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D1429093491"
+        },
+        "realtime": true,
+        "routeId": "=Lh0XlJWEeA==",
+        "registerJourney": {
+            "url": "https://treinwijzer.ns.nl/idp/login?ctxRecon=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T18%3A44%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A35%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D1429093491&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "searchUrl": "https://treinwijzer.ns.nl/idp/login?search=true&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "status": "REGISTRATION_POSSIBLE",
+            "bicycleReservationRequired": false
+        },
+        "modalityListItems": [{
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "7",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "8b",
+            "accessibilityName": "Intercity"
+        }]
+    }, {
+        "idx": 2,
+        "uid": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T18:44:00+02:00|plannedArrivalTime=2025-04-05T20:40:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=3500506933",
+        "ctxRecon": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T18:44:00+02:00|plannedArrivalTime=2025-04-05T20:40:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=3500506933",
+        "sourceCtxRecon": "¶HKI¶T$A=1@O=Alkmaar@L=1101021@a=128@$A=1@O=Utrecht Centraal@L=1100728@a=128@$202504051844$202504051951$IC 3071 $$1$$$$$$§W$A=1@O=Utrecht Centraal@L=1100728@a=128@$A=1@O=Utrecht Centraal@L=1100697@a=128@$202504051951$202504051956$$$1$$$$$$§T$A=1@O=Utrecht Centraal@L=1100697@a=128@$A=1@O=Rotterdam Centraal@L=1100690@a=128@$202504052003$202504052040$IC 2868 $$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#16481#AM2#0#RT#31#¶KCC¶#VE#0#ERG#8451#HIN#0#ECK#11204|11204|11288|11320|0|0|325|11195|3|0|10|0|0|-2147483648#¶KRCC¶#VE#1#MRTF#",
+        "plannedDurationInMinutes": 116,
+        "actualDurationInMinutes": 116,
+        "transfers": 1,
+        "status": "NORMAL",
+        "messages": [],
+        "legs": [{
+            "idx": "0",
+            "name": "IC 3071",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Nijmegen",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539273#TA#0#DA#50425#1S#1101028#1T#1804#LS#1101149#LT#2047#PU#784#RT#1#CA#IC#ZE#3071#ZB#IC 3071 #PC#1#FR#1101028#FT#1804#TO#1101149#TT#2047#",
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T18:44:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T18:44:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "checkinStatus": "CHECKIN",
+                "notes": []
+            },
+            "destination": {
+                "name": "Utrecht Centraal",
+                "lng": 5.11027765274048,
+                "lat": 52.0888900756836,
+                "countryCode": "NL",
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "stationCode": "UT",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:51:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T19:51:00+0200",
+                "plannedTrack": "19",
+                "actualTrack": "19",
+                "exitSide": "LEFT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3071",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Nijmegen",
+                        "shortValue": "to Nijmegen",
+                        "accessibilityValue": "to Nijmegen",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "6 intermediate stops",
+                        "shortValue": "6 intermediate stops",
+                        "accessibilityValue": "6 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "stops": [{
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "name": "Alkmaar",
+                "lat": 52.6377792358398,
+                "lng": 4.73972225189209,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T18:44:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:44:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "departureDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400309",
+                "uicCdCode": "118400309",
+                "name": "Heiloo",
+                "lat": 52.5994453430176,
+                "lng": 4.70055532455444,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T18:49:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:49:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T18:49:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T18:49:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400151",
+                "uicCdCode": "118400151",
+                "name": "Castricum",
+                "lat": 52.5458335876465,
+                "lng": 4.65861129760742,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedDepartureDateTime": "2025-04-05T18:55:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T18:55:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T18:55:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T18:55:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400731",
+                "uicCdCode": "118400731",
+                "name": "Zaandam",
+                "lat": 52.4388885498047,
+                "lng": 4.81361103057861,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T19:08:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T19:08:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:08:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:08:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedDepartureDateTime": "2025-04-05T19:15:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T19:15:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:15:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:15:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400058",
+                "uicCdCode": "118400058",
+                "name": "Amsterdam Centraal",
+                "lat": 52.3788871765137,
+                "lng": 4.90027761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 10,
+                "plannedDepartureDateTime": "2025-04-05T19:24:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T19:24:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:21:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:21:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400057",
+                "uicCdCode": "118400057",
+                "name": "Amsterdam Amstel",
+                "lat": 52.3466682434082,
+                "lng": 4.91777801513672,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 12,
+                "plannedDepartureDateTime": "2025-04-05T19:32:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T19:32:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:31:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:31:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "name": "Utrecht Centraal",
+                "lat": 52.0888900756836,
+                "lng": 5.11027765274048,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 20,
+                "plannedArrivalDateTime": "2025-04-05T19:51:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T19:51:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "19",
+                "plannedDepartureTrack": "19",
+                "plannedArrivalTrack": "19",
+                "actualArrivalTrack": "19",
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "punctuality": 90.0,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539273#TA#0#DA#50425#1S#1101028#1T#1804#LS#1101149#LT#2047#PU#784#RT#1#CA#IC#ZE#3071#ZB#IC 3071 #PC#1#FR#1101028#FT#1804#TO#1101149#TT#2047#&train=3071&datetime=2025-04-05T18:44:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 67,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "1:07 h.",
+                "accessibilityValue": "1 hour and 7 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 5
+        }, {
+            "idx": "1",
+            "name": "IC 2868",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Rotterdam Centraal",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#529#TA#0#DA#50425#1S#1100691#1T#1813#LS#1100690#LT#2040#PU#784#RT#1#CA#IC#ZE#1768#ZB#IC 1768 #PC#1#FR#1100691#FT#1813#TO#1100690#TT#2040#",
+            "origin": {
+                "name": "Utrecht Centraal",
+                "lng": 5.11027765274048,
+                "lat": 52.0888900756836,
+                "countryCode": "NL",
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "stationCode": "UT",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:03:00+0200",
+                "plannedTrack": "8",
+                "actualTrack": "8",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:40:00+0200",
+                "plannedTrack": "14",
+                "actualTrack": "14",
+                "exitSide": "RIGHT",
+                "checkinStatus": "CHECKOUT",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "2868",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Rotterdam Centraal",
+                        "shortValue": "to Rotterdam Centraal",
+                        "accessibilityValue": "to Rotterdam Centraal",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "2 intermediate stops",
+                        "shortValue": "2 intermediate stops",
+                        "accessibilityValue": "2 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "transferMessages": [{
+                "message": "12 min. transfer time",
+                "accessibilityMessage": "12 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "name": "Utrecht Centraal",
+                "lat": 52.0888900756836,
+                "lng": 5.11027765274048,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T20:03:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "8",
+                "plannedDepartureTrack": "8",
+                "plannedArrivalTrack": "8",
+                "actualArrivalTrack": "8",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400258",
+                "uicCdCode": "118400258",
+                "name": "Gouda",
+                "lat": 52.0175018310547,
+                "lng": 4.70444440841675,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 6,
+                "plannedDepartureDateTime": "2025-04-05T20:22:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:21:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "8",
+                "plannedDepartureTrack": "8",
+                "plannedArrivalTrack": "8",
+                "actualArrivalTrack": "8",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400507",
+                "uicCdCode": "118400507",
+                "name": "Rotterdam Alexander",
+                "lat": 51.9519462585449,
+                "lng": 4.55361127853394,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedDepartureDateTime": "2025-04-05T20:31:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:31:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "name": "Rotterdam Centraal",
+                "lat": 51.9249992370605,
+                "lng": 4.46888875961304,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 11,
+                "plannedArrivalDateTime": "2025-04-05T20:40:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "14",
+                "plannedDepartureTrack": "14",
+                "plannedArrivalTrack": "14",
+                "actualArrivalTrack": "14",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 6,
+            "punctuality": 90.0,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#529#TA#0#DA#50425#1S#1100691#1T#1813#LS#1100690#LT#2040#PU#784#RT#1#CA#IC#ZE#1768#ZB#IC 1768 #PC#1#FR#1100691#FT#1813#TO#1100690#TT#2040#&train=2868&datetime=2025-04-05T20:03:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 37,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "37 min.",
+                "accessibilityValue": "37 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": []
+        }],
+        "checksum": "96feda2c_3",
+        "crowdForecast": "LOW",
+        "punctuality": 90.0,
+        "optimal": false,
+        "fareRoute": {
+            "routeId": "=Lh0XlJWEeA==",
+            "origin": {
+                "varCode": 50,
+                "name": "Alkmaar"
+            },
+            "destination": {
+                "varCode": 530,
+                "name": "Rotterdam Centraal"
+            }
+        },
+        "fares": [{
+            "priceInCents": 3672,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2938,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 1728,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 2203,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 1296,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 7344,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 4320,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 5876,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 3456,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 4406,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 2592,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 63870,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 37570,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 766440,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 450840,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }],
+        "fareLegs": [{
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION"
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION"
+            },
+            "operator": "NS",
+            "productTypes": ["TRAIN"],
+            "fares": [{
+                "priceInCents": 2160,
+                "priceInCentsExcludingSupplement": 2160,
+                "supplementInCents": 0,
+                "buyableTicketSupplementPriceInCents": 0,
+                "product": "OVCHIPKAART_ENKELE_REIS",
+                "travelClass": "SECOND_CLASS",
+                "discountType": "NO_DISCOUNT"
+            }],
+            "travelDate": "2025-04-05"
+        }],
+        "productFare": {
+            "priceInCents": 2160,
+            "priceInCentsExcludingSupplement": 2160,
+            "buyableTicketPriceInCents": 2160,
+            "buyableTicketPriceInCentsExcludingSupplement": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        },
+        "fareOptions": {
+            "isInternationalBookable": false,
+            "isInternational": false,
+            "isEticketBuyable": true,
+            "isPossibleWithOvChipkaart": true,
+            "isTotalPriceUnknown": false
+        },
+        "nsiLink": {
+            "url": "https://www.nsinternational.com/en/traintickets-v3/#/search/AMR/RTD/20250405/1844/2040?stationType=domestic&cookieConsent=false",
+            "showInternationalBanner": false
+        },
+        "type": "NS",
+        "shareUrl": {
+            "uri": "https://www.ns.nl/rpx?ctx=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T18%3A44%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A40%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D3500506933"
+        },
+        "realtime": true,
+        "routeId": "=Lh0XlJWEeA==",
+        "registerJourney": {
+            "url": "https://treinwijzer.ns.nl/idp/login?ctxRecon=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T18%3A44%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A40%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D3500506933&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "searchUrl": "https://treinwijzer.ns.nl/idp/login?search=true&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "status": "REGISTRATION_POSSIBLE",
+            "bicycleReservationRequired": false
+        },
+        "modalityListItems": [{
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "8",
+            "accessibilityName": "Intercity"
+        }]
+    }, {
+        "idx": 3,
+        "uid": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:02:00+02:00|plannedArrivalTime=2025-04-05T21:04:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=3027949750",
+        "ctxRecon": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:02:00+02:00|plannedArrivalTime=2025-04-05T21:04:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=3027949750",
+        "sourceCtxRecon": "¶HKI¶T$A=1@O=Alkmaar@L=1101021@a=128@$A=1@O=Rotterdam Centraal@L=1100688@a=128@$202504051902$202504052104$SPR 4075$$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#16481#AM2#0#RT#31#¶KCC¶#VE#0#ERG#8193#HIN#0#ECK#11234|11222|11319|11344|0|0|325|11205|4|0|10|0|0|-2147483648#¶KRCC¶#VE#1#MRTF#",
+        "plannedDurationInMinutes": 122,
+        "actualDurationInMinutes": 122,
+        "transfers": 0,
+        "status": "NORMAL",
+        "messages": [],
+        "legs": [{
+            "idx": "0",
+            "name": "SPR 4075",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Rotterdam Centraal",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#4002#TA#1#DA#50425#1S#1101056#1T#1835#LS#1100688#LT#2104#PU#784#RT#1#CA#SPR#ZE#4075#ZB#SPR 4075#PC#3#FR#1101056#FT#1835#TO#1100688#TT#2104#",
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:02:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "checkinStatus": "CHECKIN",
+                "notes": []
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T21:04:00+0200",
+                "plannedTrack": "16",
+                "actualTrack": "16",
+                "exitSide": "RIGHT",
+                "checkinStatus": "CHECKOUT",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "4075",
+                "categoryCode": "SPR",
+                "shortCategoryName": "SPR",
+                "longCategoryName": "Sprinter",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Sprinter",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Sprinter",
+                        "shortValue": "NS Sprinter",
+                        "accessibilityValue": "NS Sprinter",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Rotterdam Centraal via Uitgeest",
+                        "shortValue": "to Rotterdam Centraal via Uitgeest",
+                        "accessibilityValue": "to Rotterdam Centraal via Uitgeest",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "24 intermediate stops",
+                        "shortValue": "24 intermediate stops",
+                        "accessibilityValue": "24 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "stops": [{
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "name": "Alkmaar",
+                "lat": 52.6377792358398,
+                "lng": 4.73972225189209,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:02:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400309",
+                "uicCdCode": "118400309",
+                "name": "Heiloo",
+                "lat": 52.5994453430176,
+                "lng": 4.70055532455444,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T19:07:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:07:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400151",
+                "uicCdCode": "118400151",
+                "name": "Castricum",
+                "lat": 52.5458335876465,
+                "lng": 4.65861129760742,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedDepartureDateTime": "2025-04-05T19:12:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:12:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400615",
+                "uicCdCode": "118400615",
+                "name": "Uitgeest",
+                "lat": 52.5216674804687,
+                "lng": 4.70166683197022,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 3,
+                "plannedDepartureDateTime": "2025-04-05T19:18:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:17:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400368",
+                "uicCdCode": "118400368",
+                "name": "Krommenie-Assendelft",
+                "lat": 52.49511,
+                "lng": 4.75417,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 4,
+                "plannedDepartureDateTime": "2025-04-05T19:23:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:23:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400707",
+                "uicCdCode": "118400707",
+                "name": "Wormerveer",
+                "lat": 52.4891662597656,
+                "lng": 4.79222202301025,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 5,
+                "plannedDepartureDateTime": "2025-04-05T19:26:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:26:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400364",
+                "uicCdCode": "118400364",
+                "name": "Zaandijk Zaanse Schans",
+                "lat": 52.469165802002,
+                "lng": 4.80499982833862,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 6,
+                "plannedDepartureDateTime": "2025-04-05T19:29:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:29:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400363",
+                "uicCdCode": "118400363",
+                "name": "Koog aan de Zaan",
+                "lat": 52.458610534668,
+                "lng": 4.80555534362793,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 7,
+                "plannedDepartureDateTime": "2025-04-05T19:32:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:32:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400731",
+                "uicCdCode": "118400731",
+                "name": "Zaandam",
+                "lat": 52.4388885498047,
+                "lng": 4.81361103057861,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T19:35:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:35:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedDepartureDateTime": "2025-04-05T19:41:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:41:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "6",
+                "plannedDepartureTrack": "6",
+                "plannedArrivalTrack": "6",
+                "actualArrivalTrack": "6",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400058",
+                "uicCdCode": "118400058",
+                "name": "Amsterdam Centraal",
+                "lat": 52.3788871765137,
+                "lng": 4.90027761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 10,
+                "plannedDepartureDateTime": "2025-04-05T19:49:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:47:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2b",
+                "plannedDepartureTrack": "2b",
+                "plannedArrivalTrack": "2b",
+                "actualArrivalTrack": "2b",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400060",
+                "uicCdCode": "118400060",
+                "name": "Amsterdam Muiderpoort",
+                "lat": 52.3605537414551,
+                "lng": 4.93111133575439,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 11,
+                "plannedDepartureDateTime": "2025-04-05T19:54:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:54:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "9",
+                "plannedDepartureTrack": "9",
+                "plannedArrivalTrack": "9",
+                "actualArrivalTrack": "9",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400057",
+                "uicCdCode": "118400057",
+                "name": "Amsterdam Amstel",
+                "lat": 52.3466682434082,
+                "lng": 4.91777801513672,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 12,
+                "plannedDepartureDateTime": "2025-04-05T19:58:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:58:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400194",
+                "uicCdCode": "118400194",
+                "name": "Duivendrecht",
+                "lat": 52.3233337402344,
+                "lng": 4.93638896942139,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 13,
+                "plannedDepartureDateTime": "2025-04-05T20:01:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:01:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "8",
+                "plannedDepartureTrack": "8",
+                "plannedArrivalTrack": "8",
+                "actualArrivalTrack": "8",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400074",
+                "uicCdCode": "118400074",
+                "name": "Amsterdam Bijlmer ArenA",
+                "lat": 52.3122215270996,
+                "lng": 4.94694423675537,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 14,
+                "plannedDepartureDateTime": "2025-04-05T20:04:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:04:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "6",
+                "plannedDepartureTrack": "6",
+                "plannedArrivalTrack": "6",
+                "actualArrivalTrack": "6",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400231",
+                "uicCdCode": "118400231",
+                "name": "Amsterdam Holendrecht",
+                "lat": 52.29844,
+                "lng": 4.95972,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 15,
+                "plannedDepartureDateTime": "2025-04-05T20:06:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:06:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400047",
+                "uicCdCode": "118400047",
+                "name": "Abcoude",
+                "lat": 52.2785,
+                "lng": 4.977,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 16,
+                "plannedDepartureDateTime": "2025-04-05T20:10:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:10:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400133",
+                "uicCdCode": "118400133",
+                "name": "Breukelen",
+                "lat": 52.17149,
+                "lng": 4.9906,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 17,
+                "plannedDepartureDateTime": "2025-04-05T20:18:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:18:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400702",
+                "uicCdCode": "118400702",
+                "name": "Woerden",
+                "lat": 52.0849990844727,
+                "lng": 4.89361095428467,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 18,
+                "plannedDepartureDateTime": "2025-04-05T20:28:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:26:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400257",
+                "uicCdCode": "118400257",
+                "name": "Gouda Goverwelle",
+                "lat": 52.0149993896484,
+                "lng": 4.7408332824707,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 19,
+                "plannedDepartureDateTime": "2025-04-05T20:37:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:37:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400258",
+                "uicCdCode": "118400258",
+                "name": "Gouda",
+                "lat": 52.0175018310547,
+                "lng": 4.70444440841675,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 20,
+                "plannedDepartureDateTime": "2025-04-05T20:41:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:40:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "8",
+                "plannedDepartureTrack": "8",
+                "plannedArrivalTrack": "8",
+                "actualArrivalTrack": "8",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400455",
+                "uicCdCode": "118400455",
+                "name": "Nieuwerkerk a/d IJssel",
+                "lat": 51.9652786254883,
+                "lng": 4.61694431304932,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 21,
+                "plannedDepartureDateTime": "2025-04-05T20:48:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:48:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400147",
+                "uicCdCode": "118400147",
+                "name": "Capelle Schollevaar",
+                "lat": 51.9541664123535,
+                "lng": 4.58416652679443,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 22,
+                "plannedDepartureDateTime": "2025-04-05T20:51:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:51:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400507",
+                "uicCdCode": "118400507",
+                "name": "Rotterdam Alexander",
+                "lat": 51.9519462585449,
+                "lng": 4.55361127853394,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 23,
+                "plannedDepartureDateTime": "2025-04-05T20:54:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:54:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400531",
+                "uicCdCode": "118400531",
+                "name": "Rotterdam Noord",
+                "lat": 51.9422225952148,
+                "lng": 4.48166656494141,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 24,
+                "plannedDepartureDateTime": "2025-04-05T20:58:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:58:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "name": "Rotterdam Centraal",
+                "lat": 51.9249992370605,
+                "lng": 4.46888875961304,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 25,
+                "plannedArrivalDateTime": "2025-04-05T21:04:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "16",
+                "plannedDepartureTrack": "16",
+                "plannedArrivalTrack": "16",
+                "actualArrivalTrack": "16",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "punctuality": 100.0,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#4002#TA#1#DA#50425#1S#1101056#1T#1835#LS#1100688#LT#2104#PU#784#RT#1#CA#SPR#ZE#4075#ZB#SPR 4075#PC#3#FR#1101056#FT#1835#TO#1100688#TT#2104#&train=4075&datetime=2025-04-05T19:02:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 122,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "2:02 h.",
+                "accessibilityValue": "2 hours and 2 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": []
+        }],
+        "checksum": "956a30b9_3",
+        "crowdForecast": "LOW",
+        "punctuality": 100.0,
+        "optimal": false,
+        "fareRoute": {
+            "routeId": "=Lh0XlJWEeA==",
+            "origin": {
+                "varCode": 50,
+                "name": "Alkmaar"
+            },
+            "destination": {
+                "varCode": 530,
+                "name": "Rotterdam Centraal"
+            }
+        },
+        "fares": [{
+            "priceInCents": 3672,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2938,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 1728,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 2203,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 1296,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 7344,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 4320,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 5876,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 3456,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 4406,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 2592,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 63870,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 37570,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 766440,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 450840,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }],
+        "fareLegs": [{
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION"
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION"
+            },
+            "operator": "NS",
+            "productTypes": ["TRAIN"],
+            "fares": [{
+                "priceInCents": 2160,
+                "priceInCentsExcludingSupplement": 2160,
+                "supplementInCents": 0,
+                "buyableTicketSupplementPriceInCents": 0,
+                "product": "OVCHIPKAART_ENKELE_REIS",
+                "travelClass": "SECOND_CLASS",
+                "discountType": "NO_DISCOUNT"
+            }],
+            "travelDate": "2025-04-05"
+        }],
+        "productFare": {
+            "priceInCents": 2160,
+            "priceInCentsExcludingSupplement": 2160,
+            "buyableTicketPriceInCents": 2160,
+            "buyableTicketPriceInCentsExcludingSupplement": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        },
+        "fareOptions": {
+            "isInternationalBookable": false,
+            "isInternational": false,
+            "isEticketBuyable": true,
+            "isPossibleWithOvChipkaart": true,
+            "isTotalPriceUnknown": false
+        },
+        "nsiLink": {
+            "url": "https://www.nsinternational.com/en/traintickets-v3/#/search/AMR/RTD/20250405/1902/2104?stationType=domestic&cookieConsent=false",
+            "showInternationalBanner": false
+        },
+        "type": "NS",
+        "shareUrl": {
+            "uri": "https://www.ns.nl/rpx?ctx=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A02%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T21%3A04%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D3027949750"
+        },
+        "realtime": true,
+        "routeId": "=Lh0XlJWEeA==",
+        "registerJourney": {
+            "url": "https://treinwijzer.ns.nl/idp/login?ctxRecon=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A02%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T21%3A04%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D3027949750&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "searchUrl": "https://treinwijzer.ns.nl/idp/login?search=true&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "status": "REGISTRATION_POSSIBLE",
+            "bicycleReservationRequired": false
+        },
+        "modalityListItems": [{
+            "name": "Sprinter",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5",
+            "accessibilityName": "Sprinter"
+        }]
+    }, {
+        "idx": 4,
+        "uid": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:14:00+02:00|plannedArrivalTime=2025-04-05T20:39:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=1970294765",
+        "ctxRecon": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:14:00+02:00|plannedArrivalTime=2025-04-05T20:39:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=1970294765",
+        "sourceCtxRecon": "¶HKI¶T$A=1@O=Alkmaar@L=1101021@a=128@$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$202504051914$202504051945$IC 3073 $$1$$$$$$§W$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$A=1@O=Amsterdam Sloterdijk@L=1100933@a=128@$202504051945$202504051950$$$1$$$$$$§T$A=1@O=Amsterdam Sloterdijk@L=1100933@a=128@$A=1@O=Schiphol Airport@L=1100911@a=128@$202504051955$202504052005$SPR 8275$$1$$$$$$§W$A=1@O=Schiphol Airport@L=1100911@a=128@$A=1@O=Schiphol Airport@L=1100725@a=128@$202504052005$202504052009$$$1$$$$$$§T$A=1@O=Schiphol Airport@L=1100725@a=128@$A=1@O=Rotterdam Centraal@L=1100718@a=128@$202504052011$202504052039$ECD 9568$$1$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#16481#AM2#0#RT#31#¶KCC¶#VE#0#ERG#5#HIN#0#ECK#11234|11234|11319|11319|0|0|65861|11205|5|0|2|0|0|-2147483648#¶KRCC¶#VE#1#MRTF#",
+        "plannedDurationInMinutes": 85,
+        "actualDurationInMinutes": 85,
+        "transfers": 2,
+        "status": "NORMAL",
+        "messages": [],
+        "legs": [{
+            "idx": "0",
+            "name": "IC 3073",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Nijmegen",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539293#TA#0#DA#50425#1S#1101022#1T#1834#LS#1101145#LT#2117#PU#784#RT#1#CA#IC#ZE#3073#ZB#IC 3073 #PC#1#FR#1101022#FT#1834#TO#1101145#TT#2117#",
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:14:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "checkinStatus": "CHECKIN",
+                "notes": []
+            },
+            "destination": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:45:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "exitSide": "RIGHT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3073",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Nijmegen",
+                        "shortValue": "to Nijmegen",
+                        "accessibilityValue": "to Nijmegen",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "3 intermediate stops",
+                        "shortValue": "3 intermediate stops",
+                        "accessibilityValue": "3 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "stops": [{
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "name": "Alkmaar",
+                "lat": 52.6377792358398,
+                "lng": 4.73972225189209,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:14:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400309",
+                "uicCdCode": "118400309",
+                "name": "Heiloo",
+                "lat": 52.5994453430176,
+                "lng": 4.70055532455444,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T19:19:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:19:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400151",
+                "uicCdCode": "118400151",
+                "name": "Castricum",
+                "lat": 52.5458335876465,
+                "lng": 4.65861129760742,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedDepartureDateTime": "2025-04-05T19:25:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:25:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400731",
+                "uicCdCode": "118400731",
+                "name": "Zaandam",
+                "lat": 52.4388885498047,
+                "lng": 4.81361103057861,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T19:38:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:38:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedArrivalDateTime": "2025-04-05T19:45:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 6,
+            "punctuality": 100.0,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539293#TA#0#DA#50425#1S#1101022#1T#1834#LS#1101145#LT#2117#PU#784#RT#1#CA#IC#ZE#3073#ZB#IC 3073 #PC#1#FR#1101022#FT#1834#TO#1101145#TT#2117#&train=3073&datetime=2025-04-05T19:14:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 31,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "31 min.",
+                "accessibilityValue": "31 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 5
+        }, {
+            "idx": "1",
+            "name": "SPR 8275",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Hoofddorp",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#7524#TA#0#DA#50425#1S#1100807#1T#1949#LS#1101153#LT#2012#PU#784#RT#1#CA#SPR#ZE#8275#ZB#SPR 8275#PC#3#FR#1100807#FT#1949#TO#1101153#TT#2012#",
+            "origin": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:55:00+0200",
+                "plannedTrack": "11",
+                "actualTrack": "11",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Schiphol Airport ✈",
+                "lng": 4.76194429397583,
+                "lat": 52.3094444274902,
+                "countryCode": "NL",
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "stationCode": "SHL",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:05:00+0200",
+                "plannedTrack": "4",
+                "actualTrack": "4",
+                "exitSide": "LEFT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "8275",
+                "categoryCode": "SPR",
+                "shortCategoryName": "SPR",
+                "longCategoryName": "Sprinter",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Sprinter",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Sprinter",
+                        "shortValue": "NS Sprinter",
+                        "accessibilityValue": "NS Sprinter",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Hoofddorp",
+                        "shortValue": "to Hoofddorp",
+                        "accessibilityValue": "to Hoofddorp",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "1 intermediate stop",
+                        "shortValue": "1 intermediate stop",
+                        "accessibilityValue": "1 intermediate stop",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "notes": [{
+                "value": "Check out and in not needed",
+                "accessibilityValue": "Check out and in not needed",
+                "key": "CHECK_OUT_IN_NOT_REQUIRED",
+                "noteType": "UNKNOWN",
+                "isPresentationRequired": false
+            }],
+            "transferMessages": [{
+                "message": "10 min. transfer time",
+                "accessibilityMessage": "10 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:55:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "11",
+                "plannedDepartureTrack": "11",
+                "plannedArrivalTrack": "11",
+                "actualArrivalTrack": "11",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400079",
+                "uicCdCode": "118400079",
+                "name": "Amsterdam Lelylaan",
+                "lat": 52.3577766418457,
+                "lng": 4.83388900756836,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T19:59:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:59:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "1",
+                "plannedDepartureTrack": "1",
+                "plannedArrivalTrack": "1",
+                "actualArrivalTrack": "1",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "name": "Schiphol Airport",
+                "lat": 52.3094444274902,
+                "lng": 4.76194429397583,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedArrivalDateTime": "2025-04-05T20:05:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "MEDIUM",
+            "bicycleSpotCount": 4,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#7524#TA#0#DA#50425#1S#1100807#1T#1949#LS#1101153#LT#2012#PU#784#RT#1#CA#SPR#ZE#8275#ZB#SPR 8275#PC#3#FR#1100807#FT#1949#TO#1101153#TT#2012#&train=8275&datetime=2025-04-05T19:55:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 10,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "10 min.",
+                "accessibilityValue": "10 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 4
+        }, {
+            "idx": "2",
+            "name": "ECD 9568",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Bruxelles Midi",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#429950#TA#0#DA#50425#1S#1101063#1T#2003#LS#8800004#LT#2203#PU#784#RT#1#CA#ECD#ZE#9568#ZB#ECD 9568#PC#1#FR#1101063#FT#2003#TO#8800004#TT#2203#",
+            "origin": {
+                "name": "Schiphol Airport ✈",
+                "lng": 4.76194429397583,
+                "lat": 52.3094444274902,
+                "countryCode": "NL",
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "stationCode": "SHL",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:11:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T20:11:00+0200",
+                "plannedTrack": "5-6",
+                "actualTrack": "5-6",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:39:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T20:39:00+0200",
+                "plannedTrack": "3",
+                "actualTrack": "3",
+                "exitSide": "LEFT",
+                "checkinStatus": "CHECKOUT",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "9568",
+                "categoryCode": "ECD",
+                "shortCategoryName": "ECD",
+                "longCategoryName": "Eurocity Direct",
+                "operatorCode": "NSI",
+                "operatorName": "NS International",
+                "operatorAdministrativeCode": 200,
+                "type": "TRAIN",
+                "displayName": "Eurocity Direct",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "Eurocity Direct",
+                        "shortValue": "Eurocity Direct",
+                        "accessibilityValue": "Eurocity Direct",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Bruxelles Midi",
+                        "shortValue": "to Bruxelles Midi",
+                        "accessibilityValue": "to Bruxelles Midi",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "No intermediate stops",
+                        "shortValue": "No intermediate stops",
+                        "accessibilityValue": "No intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "Supplement",
+                        "shortValue": "Supplement",
+                        "accessibilityValue": "Supplement",
+                        "key": "PRODUCT_SUPPLEMENT",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-warning-contrast",
+                            "type": "warning"
+                        }
+                    }]
+                ]
+            },
+            "notes": [{
+                "value": "Supplement",
+                "shortValue": "Supplement",
+                "accessibilityValue": "Supplement",
+                "key": "ZA",
+                "noteType": "ATTRIBUTE",
+                "isPresentationRequired": true
+            }],
+            "transferMessages": [{
+                "message": "6 min. transfer time",
+                "accessibilityMessage": "6 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400561",
+                "uicCdCode": "118400561",
+                "name": "Schiphol Airport",
+                "lat": 52.3094444274902,
+                "lng": 4.76194429397583,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T20:11:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:11:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5-6",
+                "plannedDepartureTrack": "5-6",
+                "plannedArrivalTrack": "5-6",
+                "actualArrivalTrack": "5-6",
+                "departureDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "name": "Rotterdam Centraal",
+                "lat": 51.9249992370605,
+                "lng": 4.46888875961304,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedArrivalDateTime": "2025-04-05T20:39:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:39:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "UNKNOWN",
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#429950#TA#0#DA#50425#1S#1101063#1T#2003#LS#8800004#LT#2203#PU#784#RT#1#CA#ECD#ZE#9568#ZB#ECD 9568#PC#1#FR#1101063#FT#2003#TO#8800004#TT#2203#&train=9568&datetime=2025-04-05T20:11:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 28,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "28 min.",
+                "accessibilityValue": "28 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": []
+        }],
+        "checksum": "f7191369_3",
+        "crowdForecast": "MEDIUM",
+        "punctuality": 100.0,
+        "optimal": true,
+        "fareRoute": {
+            "routeId": "=Lh0XlJWEeA==",
+            "origin": {
+                "varCode": 50,
+                "name": "Alkmaar"
+            },
+            "destination": {
+                "varCode": 530,
+                "name": "Rotterdam Centraal"
+            }
+        },
+        "fares": [{
+            "priceInCents": 3672,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2938,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 1728,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 2203,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 1296,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 7344,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 4320,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 5876,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 3456,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 4406,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 2592,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 63870,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 37570,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 766440,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 450840,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }],
+        "fareLegs": [{
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION"
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION"
+            },
+            "operator": "NS, NS International",
+            "productTypes": ["TRAIN"],
+            "fares": [{
+                "priceInCents": 2160,
+                "priceInCentsExcludingSupplement": 2160,
+                "supplementInCents": 0,
+                "buyableTicketSupplementPriceInCents": 0,
+                "product": "OVCHIPKAART_ENKELE_REIS",
+                "travelClass": "SECOND_CLASS",
+                "discountType": "NO_DISCOUNT"
+            }],
+            "travelDate": "2025-04-05"
+        }],
+        "productFare": {
+            "priceInCents": 2460,
+            "priceInCentsExcludingSupplement": 2160,
+            "supplementInCents": 300,
+            "buyableTicketPriceInCents": 2460,
+            "buyableTicketPriceInCentsExcludingSupplement": 2160,
+            "buyableTicketSupplementPriceInCents": 300,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        },
+        "fareOptions": {
+            "isInternationalBookable": false,
+            "isInternational": false,
+            "isEticketBuyable": true,
+            "isPossibleWithOvChipkaart": true,
+            "isTotalPriceUnknown": false,
+            "supplementsBasedOnSelectedFare": [{
+                "supplementPriceInCents": 300,
+                "fromUICCode": "8400050",
+                "toUICCode": "8400530",
+                "link": {
+                    "uri": "/api/v1/catalogue/intercity-direct"
+                },
+                "supplementType": "ICD"
+            }]
+        },
+        "nsiLink": {
+            "url": "https://www.nsinternational.com/en/traintickets-v3/#/search/AMR/RTD/20250405/1914/2039?stationType=domestic&cookieConsent=false",
+            "showInternationalBanner": false
+        },
+        "type": "NS",
+        "shareUrl": {
+            "uri": "https://www.ns.nl/rpx?ctx=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A14%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A39%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D1970294765"
+        },
+        "realtime": true,
+        "routeId": "=Lh0XlJWEeA==",
+        "registerJourney": {
+            "url": "https://treinwijzer.ns.nl/idp/login?ctxRecon=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A14%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T20%3A39%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D1970294765&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "searchUrl": "https://treinwijzer.ns.nl/idp/login?search=true&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "status": "REGISTRATION_POSSIBLE",
+            "bicycleReservationRequired": false
+        },
+        "modalityListItems": [{
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Sprinter",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "11",
+            "accessibilityName": "Sprinter"
+        }, {
+            "name": "Eurocity Direct",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5-6",
+            "accessibilityName": "Eurocity Direct"
+        }],
+        "labelListItems": [{
+            "label": "€ 3.00 supplement",
+            "stickerType": "default"
+        }]
+    }, {
+        "idx": 5,
+        "uid": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:14:00+02:00|plannedArrivalTime=2025-04-05T21:05:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=400253363",
+        "ctxRecon": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:14:00+02:00|plannedArrivalTime=2025-04-05T21:05:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=400253363",
+        "sourceCtxRecon": "¶HKI¶T$A=1@O=Alkmaar@L=1101021@a=128@$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$202504051914$202504051945$IC 3073 $$1$$$$$$§W$A=1@O=Amsterdam Sloterdijk@L=1100835@a=128@$A=1@O=Amsterdam Sloterdijk@L=1101087@a=128@$202504051945$202504051949$$$1$$$$$$§T$A=1@O=Amsterdam Sloterdijk@L=1101087@a=128@$A=1@O=Leiden Centraal@L=1100917@a=128@$202504051955$202504052026$IC 2179 $$1$$$$$$§W$A=1@O=Leiden Centraal@L=1100917@a=128@$A=1@O=Leiden Centraal@L=1100721@a=128@$202504052026$202504052028$$$1$$$$$$§T$A=1@O=Leiden Centraal@L=1100721@a=128@$A=1@O=Rotterdam Centraal@L=1100936@a=128@$202504052032$202504052105$IC 3568 $$3$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#16481#AM2#0#RT#31#¶KCC¶#VE#0#ERG#45317#HIN#0#ECK#11234|11234|11319|11345|0|0|65861|11205|6|0|8|0|0|-2147483648#¶KRCC¶#VE#1#MRTF#",
+        "plannedDurationInMinutes": 111,
+        "actualDurationInMinutes": 111,
+        "transfers": 2,
+        "status": "NORMAL",
+        "messages": [],
+        "legs": [{
+            "idx": "0",
+            "name": "IC 3073",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Nijmegen",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539293#TA#0#DA#50425#1S#1101022#1T#1834#LS#1101145#LT#2117#PU#784#RT#1#CA#IC#ZE#3073#ZB#IC 3073 #PC#1#FR#1101022#FT#1834#TO#1101145#TT#2117#",
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:14:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "checkinStatus": "CHECKIN",
+                "notes": []
+            },
+            "destination": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:45:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "exitSide": "RIGHT",
+                "checkinStatus": "DETOUR",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3073",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Nijmegen",
+                        "shortValue": "to Nijmegen",
+                        "accessibilityValue": "to Nijmegen",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "3 intermediate stops",
+                        "shortValue": "3 intermediate stops",
+                        "accessibilityValue": "3 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "notes": [{
+                "value": "Avoid extra costs: transfer via the station hall",
+                "accessibilityValue": "Avoid extra costs: transfer via the station hall",
+                "key": "CheckInOutText",
+                "noteType": "UNKNOWN",
+                "isPresentationRequired": false
+            }],
+            "stops": [{
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "name": "Alkmaar",
+                "lat": 52.6377792358398,
+                "lng": 4.73972225189209,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:14:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400309",
+                "uicCdCode": "118400309",
+                "name": "Heiloo",
+                "lat": 52.5994453430176,
+                "lng": 4.70055532455444,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T19:19:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:19:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400151",
+                "uicCdCode": "118400151",
+                "name": "Castricum",
+                "lat": 52.5458335876465,
+                "lng": 4.65861129760742,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedDepartureDateTime": "2025-04-05T19:25:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:25:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400731",
+                "uicCdCode": "118400731",
+                "name": "Zaandam",
+                "lat": 52.4388885498047,
+                "lng": 4.81361103057861,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T19:38:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:38:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedArrivalDateTime": "2025-04-05T19:45:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 6,
+            "punctuality": 100.0,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539293#TA#0#DA#50425#1S#1101022#1T#1834#LS#1101145#LT#2117#PU#784#RT#1#CA#IC#ZE#3073#ZB#IC 3073 #PC#1#FR#1101022#FT#1834#TO#1101145#TT#2117#&train=3073&datetime=2025-04-05T19:14:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 31,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "31 min.",
+                "accessibilityValue": "31 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 4
+        }, {
+            "idx": "1",
+            "name": "IC 2179",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Leiden Centraal",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#1040#TA#1#DA#50425#1S#1100916#1T#1950#LS#1100917#LT#2026#PU#784#RT#1#CA#IC#ZE#2179#ZB#IC 2179 #PC#1#FR#1100916#FT#1950#TO#1100917#TT#2026#",
+            "origin": {
+                "name": "Amsterdam Sloterdijk",
+                "lng": 4.83777761459351,
+                "lat": 52.3888893127441,
+                "countryCode": "NL",
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "stationCode": "ASS",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:55:00+0200",
+                "plannedTrack": "7",
+                "actualTrack": "7",
+                "checkinStatus": "DETOUR",
+                "notes": []
+            },
+            "destination": {
+                "name": "Leiden Centraal",
+                "lng": 4.48166656494141,
+                "lat": 52.1661109924316,
+                "countryCode": "NL",
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "stationCode": "LEDN",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:26:00+0200",
+                "plannedTrack": "9b",
+                "actualTrack": "9b",
+                "exitSide": "LEFT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "2179",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Leiden Centraal",
+                        "shortValue": "to Leiden Centraal",
+                        "accessibilityValue": "to Leiden Centraal",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "2 intermediate stops",
+                        "shortValue": "2 intermediate stops",
+                        "accessibilityValue": "2 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "transferMessages": [{
+                "message": "10 min. transfer time",
+                "accessibilityMessage": "10 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }, {
+                "message": "Avoid extra costs: transfer via the station hall",
+                "accessibilityMessage": "Avoid extra costs: transfer via the station hall",
+                "type": "SPECIAL",
+                "messageNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "pink-500",
+                    "icon": "ov-chipkaart"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:55:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "7",
+                "plannedDepartureTrack": "7",
+                "plannedArrivalTrack": "7",
+                "actualArrivalTrack": "7",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400285",
+                "uicCdCode": "118400285",
+                "name": "Haarlem",
+                "lat": 52.3877792358398,
+                "lng": 4.63833332061768,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 3,
+                "plannedDepartureDateTime": "2025-04-05T20:07:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:05:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "6",
+                "plannedDepartureTrack": "6",
+                "plannedArrivalTrack": "6",
+                "actualArrivalTrack": "6",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400302",
+                "uicCdCode": "118400302",
+                "name": "Heemstede-Aerdenhout",
+                "lat": 52.3591651916504,
+                "lng": 4.60666656494141,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 4,
+                "plannedDepartureDateTime": "2025-04-05T20:12:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:12:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "name": "Leiden Centraal",
+                "lat": 52.1661109924316,
+                "lng": 4.48166656494141,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 7,
+                "plannedArrivalDateTime": "2025-04-05T20:26:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "9b",
+                "plannedDepartureTrack": "9b",
+                "plannedArrivalTrack": "9b",
+                "actualArrivalTrack": "9b",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 6,
+            "punctuality": 100.0,
+            "crossPlatformTransfer": true,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#1040#TA#1#DA#50425#1S#1100916#1T#1950#LS#1100917#LT#2026#PU#784#RT#1#CA#IC#ZE#2179#ZB#IC 2179 #PC#1#FR#1100916#FT#1950#TO#1100917#TT#2026#&train=2179&datetime=2025-04-05T19:55:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 31,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "31 min.",
+                "accessibilityValue": "31 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 2
+        }, {
+            "idx": "2",
+            "name": "IC 3568",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Dordrecht",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#619187#TA#0#DA#50425#1S#1100958#1T#1803#LS#1101093#LT#2122#PU#784#RT#3#CA#IC#ZE#3568#ZB#IC 3568 #PC#1#FR#1100958#FT#1803#TO#1101093#TT#2122#",
+            "origin": {
+                "name": "Leiden Centraal",
+                "lng": 4.48166656494141,
+                "lat": 52.1661109924316,
+                "countryCode": "NL",
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "stationCode": "LEDN",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:32:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T20:32:00+0200",
+                "plannedTrack": "8b",
+                "actualTrack": "8b",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T21:05:00+0200",
+                "actualTimeZoneOffset": 120,
+                "actualDateTime": "2025-04-05T21:05:00+0200",
+                "plannedTrack": "6",
+                "actualTrack": "6",
+                "exitSide": "LEFT",
+                "checkinStatus": "CHECKOUT",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3568",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Dordrecht",
+                        "shortValue": "to Dordrecht",
+                        "accessibilityValue": "to Dordrecht",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "4 intermediate stops",
+                        "shortValue": "4 intermediate stops",
+                        "accessibilityValue": "4 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "transferMessages": [{
+                "message": "Transfer at same platform",
+                "accessibilityMessage": "Transfer at same platform",
+                "type": "CROSS_PLATFORM",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400390",
+                "uicCdCode": "118400390",
+                "name": "Leiden Centraal",
+                "lat": 52.1661109924316,
+                "lng": 4.48166656494141,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T20:32:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:32:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "8b",
+                "plannedDepartureTrack": "8b",
+                "plannedArrivalTrack": "8b",
+                "actualArrivalTrack": "8b",
+                "departureDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400380",
+                "uicCdCode": "118400380",
+                "name": "Den Haag Laan v NOI",
+                "lat": 52.0786094665527,
+                "lng": 4.34277772903442,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 4,
+                "plannedDepartureDateTime": "2025-04-05T20:41:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:41:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:40:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:40:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400280",
+                "uicCdCode": "118400280",
+                "name": "Den Haag HS",
+                "lat": 52.0697212219238,
+                "lng": 4.32250022888184,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 5,
+                "plannedDepartureDateTime": "2025-04-05T20:46:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:46:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:44:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:44:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400170",
+                "uicCdCode": "118400170",
+                "name": "Delft",
+                "lat": 52.0066680908203,
+                "lng": 4.35638904571533,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T20:52:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T20:52:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:52:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T20:52:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "3",
+                "plannedDepartureTrack": "3",
+                "plannedArrivalTrack": "3",
+                "actualArrivalTrack": "3",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400553",
+                "uicCdCode": "118400553",
+                "name": "Schiedam Centrum",
+                "lat": 51.9212438128032,
+                "lng": 4.4089937210083,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 10,
+                "plannedDepartureDateTime": "2025-04-05T21:00:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureDateTime": "2025-04-05T21:00:00+0200",
+                "actualDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T21:00:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T21:00:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "departureDelayInSeconds": 0,
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "name": "Rotterdam Centraal",
+                "lat": 51.9249992370605,
+                "lng": 4.46888875961304,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 11,
+                "plannedArrivalDateTime": "2025-04-05T21:05:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualArrivalDateTime": "2025-04-05T21:05:00+0200",
+                "actualArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "6",
+                "plannedDepartureTrack": "6",
+                "plannedArrivalTrack": "6",
+                "actualArrivalTrack": "6",
+                "arrivalDelayInSeconds": 0,
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "HIGH",
+            "bicycleSpotCount": 6,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#619187#TA#0#DA#50425#1S#1100958#1T#1803#LS#1101093#LT#2122#PU#784#RT#3#CA#IC#ZE#3568#ZB#IC 3568 #PC#1#FR#1100958#FT#1803#TO#1101093#TT#2122#&train=3568&datetime=2025-04-05T20:32:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 33,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "33 min.",
+                "accessibilityValue": "33 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": []
+        }],
+        "checksum": "2959a751_3",
+        "crowdForecast": "HIGH",
+        "punctuality": 100.0,
+        "optimal": false,
+        "fareRoute": {
+            "routeId": "=Lh0XlJWEeA==",
+            "origin": {
+                "varCode": 50,
+                "name": "Alkmaar"
+            },
+            "destination": {
+                "varCode": 530,
+                "name": "Rotterdam Centraal"
+            }
+        },
+        "fares": [{
+            "priceInCents": 3672,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2938,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 1728,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 2203,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 1296,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 7344,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 4320,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 5876,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 3456,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 4406,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 2592,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 63870,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 37570,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 766440,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 450840,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }],
+        "fareLegs": [{
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION"
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION"
+            },
+            "operator": "NS",
+            "productTypes": ["TRAIN"],
+            "fares": [{
+                "priceInCents": 2160,
+                "priceInCentsExcludingSupplement": 2160,
+                "supplementInCents": 0,
+                "buyableTicketSupplementPriceInCents": 0,
+                "product": "OVCHIPKAART_ENKELE_REIS",
+                "travelClass": "SECOND_CLASS",
+                "discountType": "NO_DISCOUNT"
+            }],
+            "travelDate": "2025-04-05"
+        }],
+        "productFare": {
+            "priceInCents": 2160,
+            "priceInCentsExcludingSupplement": 2160,
+            "buyableTicketPriceInCents": 2160,
+            "buyableTicketPriceInCentsExcludingSupplement": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        },
+        "fareOptions": {
+            "isInternationalBookable": false,
+            "isInternational": false,
+            "isEticketBuyable": true,
+            "isPossibleWithOvChipkaart": true,
+            "isTotalPriceUnknown": false
+        },
+        "nsiLink": {
+            "url": "https://www.nsinternational.com/en/traintickets-v3/#/search/AMR/RTD/20250405/1914/2105?stationType=domestic&cookieConsent=false",
+            "showInternationalBanner": false
+        },
+        "type": "NS",
+        "shareUrl": {
+            "uri": "https://www.ns.nl/rpx?ctx=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A14%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T21%3A05%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D400253363"
+        },
+        "realtime": true,
+        "routeId": "=Lh0XlJWEeA==",
+        "registerJourney": {
+            "url": "https://treinwijzer.ns.nl/idp/login?ctxRecon=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A14%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T21%3A05%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D400253363&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "searchUrl": "https://treinwijzer.ns.nl/idp/login?search=true&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "status": "REGISTRATION_POSSIBLE",
+            "bicycleReservationRequired": false
+        },
+        "modalityListItems": [{
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "7",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "8b",
+            "accessibilityName": "Intercity"
+        }]
+    }, {
+        "idx": 6,
+        "uid": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:14:00+02:00|plannedArrivalTime=2025-04-05T21:10:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=4180974815",
+        "ctxRecon": "arnu|fromStation=8400050|toStation=8400530|plannedFromTime=2025-04-05T19:14:00+02:00|plannedArrivalTime=2025-04-05T21:10:00+02:00|excludeHighSpeedTrains=false|searchForAccessibleTrip=false|localTrainsOnly=false|disabledTransportModalities=BUS,FERRY,TRAM,METRO|travelAssistance=false|tripSummaryHash=4180974815",
+        "sourceCtxRecon": "¶HKI¶T$A=1@O=Alkmaar@L=1101021@a=128@$A=1@O=Utrecht Centraal@L=1100728@a=128@$202504051914$202504052021$IC 3073 $$1$$$$$$§W$A=1@O=Utrecht Centraal@L=1100728@a=128@$A=1@O=Utrecht Centraal@L=1100697@a=128@$202504052021$202504052026$$$1$$$$$$§T$A=1@O=Utrecht Centraal@L=1100697@a=128@$A=1@O=Rotterdam Centraal@L=1100690@a=128@$202504052033$202504052110$IC 2870 $$3$$$$$$¶KC¶#VE#2#CF#100#CA#0#CM#0#SICT#0#AM#16481#AM2#0#RT#31#¶KCC¶#VE#0#ERG#8451#HIN#0#ECK#11234|11234|11319|11350|0|0|325|11205|7|0|10|0|0|-2147483648#¶KRCC¶#VE#1#MRTF#",
+        "plannedDurationInMinutes": 116,
+        "actualDurationInMinutes": 116,
+        "transfers": 1,
+        "status": "NORMAL",
+        "messages": [],
+        "legs": [{
+            "idx": "0",
+            "name": "IC 3073",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Nijmegen",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539293#TA#0#DA#50425#1S#1101022#1T#1834#LS#1101145#LT#2117#PU#784#RT#1#CA#IC#ZE#3073#ZB#IC 3073 #PC#1#FR#1101022#FT#1834#TO#1101145#TT#2117#",
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T19:14:00+0200",
+                "plannedTrack": "5",
+                "actualTrack": "5",
+                "checkinStatus": "CHECKIN",
+                "notes": []
+            },
+            "destination": {
+                "name": "Utrecht Centraal",
+                "lng": 5.11027765274048,
+                "lat": 52.0888900756836,
+                "countryCode": "NL",
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "stationCode": "UT",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:21:00+0200",
+                "plannedTrack": "19",
+                "actualTrack": "19",
+                "exitSide": "LEFT",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "3073",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Nijmegen",
+                        "shortValue": "to Nijmegen",
+                        "accessibilityValue": "to Nijmegen",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "6 intermediate stops",
+                        "shortValue": "6 intermediate stops",
+                        "accessibilityValue": "6 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "stops": [{
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "name": "Alkmaar",
+                "lat": 52.6377792358398,
+                "lng": 4.73972225189209,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T19:14:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400309",
+                "uicCdCode": "118400309",
+                "name": "Heiloo",
+                "lat": 52.5994453430176,
+                "lng": 4.70055532455444,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 1,
+                "plannedDepartureDateTime": "2025-04-05T19:19:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:19:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400151",
+                "uicCdCode": "118400151",
+                "name": "Castricum",
+                "lat": 52.5458335876465,
+                "lng": 4.65861129760742,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 2,
+                "plannedDepartureDateTime": "2025-04-05T19:25:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:25:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400731",
+                "uicCdCode": "118400731",
+                "name": "Zaandam",
+                "lat": 52.4388885498047,
+                "lng": 4.81361103057861,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 8,
+                "plannedDepartureDateTime": "2025-04-05T19:38:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:38:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400059",
+                "uicCdCode": "118400059",
+                "name": "Amsterdam Sloterdijk",
+                "lat": 52.3888893127441,
+                "lng": 4.83777761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedDepartureDateTime": "2025-04-05T19:45:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:45:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "5",
+                "plannedDepartureTrack": "5",
+                "plannedArrivalTrack": "5",
+                "actualArrivalTrack": "5",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400058",
+                "uicCdCode": "118400058",
+                "name": "Amsterdam Centraal",
+                "lat": 52.3788871765137,
+                "lng": 4.90027761459351,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 10,
+                "plannedDepartureDateTime": "2025-04-05T19:54:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T19:51:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4b",
+                "plannedDepartureTrack": "4b",
+                "plannedArrivalTrack": "4b",
+                "actualArrivalTrack": "4b",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400057",
+                "uicCdCode": "118400057",
+                "name": "Amsterdam Amstel",
+                "lat": 52.3466682434082,
+                "lng": 4.91777801513672,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 12,
+                "plannedDepartureDateTime": "2025-04-05T20:02:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:01:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "4",
+                "plannedDepartureTrack": "4",
+                "plannedArrivalTrack": "4",
+                "actualArrivalTrack": "4",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "name": "Utrecht Centraal",
+                "lat": 52.0888900756836,
+                "lng": 5.11027765274048,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 20,
+                "plannedArrivalDateTime": "2025-04-05T20:21:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "19",
+                "plannedDepartureTrack": "19",
+                "plannedArrivalTrack": "19",
+                "actualArrivalTrack": "19",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 6,
+            "punctuality": 90.9,
+            "crossPlatformTransfer": false,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#539293#TA#0#DA#50425#1S#1101022#1T#1834#LS#1101145#LT#2117#PU#784#RT#1#CA#IC#ZE#3073#ZB#IC 3073 #PC#1#FR#1101022#FT#1834#TO#1101145#TT#2117#&train=3073&datetime=2025-04-05T19:14:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 67,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "1:07 h.",
+                "accessibilityValue": "1 hour and 7 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": [],
+            "transferTimeToNextLeg": 5
+        }, {
+            "idx": "1",
+            "name": "IC 2870",
+            "travelType": "PUBLIC_TRANSIT",
+            "direction": "Rotterdam Centraal",
+            "partCancelled": false,
+            "cancelled": false,
+            "isOnOrAfterCancelledLeg": false,
+            "changePossible": true,
+            "alternativeTransport": false,
+            "journeyDetailRef": "HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#619636#TA#0#DA#50425#1S#1100678#1T#1845#LS#1100690#LT#2110#PU#784#RT#3#CA#IC#ZE#1770#ZB#IC 1770 #PC#1#FR#1100678#FT#1845#TO#1100690#TT#2110#",
+            "origin": {
+                "name": "Utrecht Centraal",
+                "lng": 5.11027765274048,
+                "lat": 52.0888900756836,
+                "countryCode": "NL",
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "stationCode": "UT",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T20:33:00+0200",
+                "plannedTrack": "8",
+                "actualTrack": "8",
+                "checkinStatus": "NOTHING",
+                "notes": []
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION",
+                "plannedTimeZoneOffset": 120,
+                "plannedDateTime": "2025-04-05T21:10:00+0200",
+                "plannedTrack": "14",
+                "actualTrack": "14",
+                "exitSide": "RIGHT",
+                "checkinStatus": "CHECKOUT",
+                "notes": []
+            },
+            "product": {
+                "productType": "Product",
+                "number": "2870",
+                "categoryCode": "IC",
+                "shortCategoryName": "IC",
+                "longCategoryName": "Intercity",
+                "operatorCode": "NS",
+                "operatorName": "NS",
+                "operatorAdministrativeCode": 100,
+                "type": "TRAIN",
+                "displayName": "NS Intercity",
+                "nameNesProperties": {
+                    "color": "text-body"
+                },
+                "iconNesProperties": {
+                    "color": "text-body",
+                    "icon": "train"
+                },
+                "notes": [
+                    [{
+                        "value": "NS Intercity",
+                        "shortValue": "NS Intercity",
+                        "accessibilityValue": "NS Intercity",
+                        "key": "PRODUCT_NAME",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "to Rotterdam Centraal",
+                        "shortValue": "to Rotterdam Centraal",
+                        "accessibilityValue": "to Rotterdam Centraal",
+                        "key": "PRODUCT_DIRECTION",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }],
+                    [{
+                        "value": "2 intermediate stops",
+                        "shortValue": "2 intermediate stops",
+                        "accessibilityValue": "2 intermediate stops",
+                        "key": "PRODUCT_INTERMEDIATE_STOPS",
+                        "noteType": "ATTRIBUTE",
+                        "isPresentationRequired": true,
+                        "nesProperties": {
+                            "color": "text-body"
+                        }
+                    }]
+                ]
+            },
+            "transferMessages": [{
+                "message": "12 min. transfer time",
+                "accessibilityMessage": "12 minutes transfer time",
+                "type": "TRANSFER_TIME",
+                "messageNesProperties": {
+                    "color": "text-default",
+                    "type": "informative"
+                }
+            }],
+            "stops": [{
+                "uicCode": "8400621",
+                "uicCdCode": "118400621",
+                "name": "Utrecht Centraal",
+                "lat": 52.0888900756836,
+                "lng": 5.11027765274048,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 0,
+                "plannedDepartureDateTime": "2025-04-05T20:33:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "actualDepartureTrack": "8",
+                "plannedDepartureTrack": "8",
+                "plannedArrivalTrack": "8",
+                "actualArrivalTrack": "8",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400258",
+                "uicCdCode": "118400258",
+                "name": "Gouda",
+                "lat": 52.0175018310547,
+                "lng": 4.70444440841675,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 6,
+                "plannedDepartureDateTime": "2025-04-05T20:52:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T20:51:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "8",
+                "plannedDepartureTrack": "8",
+                "plannedArrivalTrack": "8",
+                "actualArrivalTrack": "8",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400507",
+                "uicCdCode": "118400507",
+                "name": "Rotterdam Alexander",
+                "lat": 51.9519462585449,
+                "lng": 4.55361127853394,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 9,
+                "plannedDepartureDateTime": "2025-04-05T21:01:00+0200",
+                "plannedDepartureTimeZoneOffset": 120,
+                "plannedArrivalDateTime": "2025-04-05T21:01:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "2",
+                "plannedDepartureTrack": "2",
+                "plannedArrivalTrack": "2",
+                "actualArrivalTrack": "2",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }, {
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "name": "Rotterdam Centraal",
+                "lat": 51.9249992370605,
+                "lng": 4.46888875961304,
+                "countryCode": "NL",
+                "notes": [],
+                "routeIdx": 11,
+                "plannedArrivalDateTime": "2025-04-05T21:10:00+0200",
+                "plannedArrivalTimeZoneOffset": 120,
+                "actualDepartureTrack": "14",
+                "plannedDepartureTrack": "14",
+                "plannedArrivalTrack": "14",
+                "actualArrivalTrack": "14",
+                "cancelled": false,
+                "borderStop": false,
+                "passing": false
+            }],
+            "crowdForecast": "LOW",
+            "bicycleSpotCount": 6,
+            "punctuality": 100.0,
+            "shorterStock": false,
+            "journeyDetail": [{
+                "type": "TRAIN_XML",
+                "link": {
+                    "uri": "/api/v2/journey?id=HARP_MM-2|#VN#1#ST#1743598653#PI#0#ZI#619636#TA#0#DA#50425#1S#1100678#1T#1845#LS#1100690#LT#2110#PU#784#RT#3#CA#IC#ZE#1770#ZB#IC 1770 #PC#1#FR#1100678#FT#1845#TO#1100690#TT#2110#&train=2870&datetime=2025-04-05T20:33:00+02:00"
+                }
+            }],
+            "reachable": true,
+            "plannedDurationInMinutes": 37,
+            "nesProperties": {
+                "color": "text-info",
+                "scope": "LEG_LINE",
+                "styles": {
+                    "type": "LineStyles",
+                    "dashed": false
+                }
+            },
+            "duration": {
+                "value": "37 min.",
+                "accessibilityValue": "37 minutes",
+                "nesProperties": {
+                    "color": "text-body"
+                }
+            },
+            "preSteps": [],
+            "postSteps": []
+        }],
+        "checksum": "87839fde_3",
+        "crowdForecast": "LOW",
+        "punctuality": 90.9,
+        "optimal": false,
+        "fareRoute": {
+            "routeId": "=Lh0XlJWEeA==",
+            "origin": {
+                "varCode": 50,
+                "name": "Alkmaar"
+            },
+            "destination": {
+                "varCode": 530,
+                "name": "Rotterdam Centraal"
+            }
+        },
+        "fares": [{
+            "priceInCents": 3672,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 2938,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 1728,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 2203,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 1296,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 7344,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 4320,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 5876,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 3456,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_20_PERCENT"
+        }, {
+            "priceInCents": 4406,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 2592,
+            "product": "OVCHIPKAART_RETOUR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "DISCOUNT_40_PERCENT"
+        }, {
+            "priceInCents": 63870,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 37570,
+            "product": "TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 766440,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "FIRST_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }, {
+            "priceInCents": 450840,
+            "product": "BUSINESS_CARD_TRAJECT_VRIJ_JAAR",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        }],
+        "fareLegs": [{
+            "origin": {
+                "name": "Alkmaar",
+                "lng": 4.73972225189209,
+                "lat": 52.6377792358398,
+                "countryCode": "NL",
+                "uicCode": "8400050",
+                "uicCdCode": "118400050",
+                "stationCode": "AMR",
+                "type": "STATION"
+            },
+            "destination": {
+                "name": "Rotterdam Centraal",
+                "lng": 4.46888875961304,
+                "lat": 51.9249992370605,
+                "countryCode": "NL",
+                "uicCode": "8400530",
+                "uicCdCode": "118400530",
+                "stationCode": "RTD",
+                "type": "STATION"
+            },
+            "operator": "NS",
+            "productTypes": ["TRAIN"],
+            "fares": [{
+                "priceInCents": 2160,
+                "priceInCentsExcludingSupplement": 2160,
+                "supplementInCents": 0,
+                "buyableTicketSupplementPriceInCents": 0,
+                "product": "OVCHIPKAART_ENKELE_REIS",
+                "travelClass": "SECOND_CLASS",
+                "discountType": "NO_DISCOUNT"
+            }],
+            "travelDate": "2025-04-05"
+        }],
+        "productFare": {
+            "priceInCents": 2160,
+            "priceInCentsExcludingSupplement": 2160,
+            "buyableTicketPriceInCents": 2160,
+            "buyableTicketPriceInCentsExcludingSupplement": 2160,
+            "product": "OVCHIPKAART_ENKELE_REIS",
+            "travelClass": "SECOND_CLASS",
+            "discountType": "NO_DISCOUNT"
+        },
+        "fareOptions": {
+            "isInternationalBookable": false,
+            "isInternational": false,
+            "isEticketBuyable": true,
+            "isPossibleWithOvChipkaart": true,
+            "isTotalPriceUnknown": false
+        },
+        "nsiLink": {
+            "url": "https://www.nsinternational.com/en/traintickets-v3/#/search/AMR/RTD/20250405/1914/2110?stationType=domestic&cookieConsent=false",
+            "showInternationalBanner": false
+        },
+        "type": "NS",
+        "shareUrl": {
+            "uri": "https://www.ns.nl/rpx?ctx=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A14%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T21%3A10%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D4180974815"
+        },
+        "realtime": true,
+        "routeId": "=Lh0XlJWEeA==",
+        "registerJourney": {
+            "url": "https://treinwijzer.ns.nl/idp/login?ctxRecon=arnu%7CfromStation%3D8400050%7CtoStation%3D8400530%7CplannedFromTime%3D2025-04-05T19%3A14%3A00%2B02%3A00%7CplannedArrivalTime%3D2025-04-05T21%3A10%3A00%2B02%3A00%7CexcludeHighSpeedTrains%3Dfalse%7CsearchForAccessibleTrip%3Dfalse%7ClocalTrainsOnly%3Dfalse%7CdisabledTransportModalities%3DBUS%2CFERRY%2CTRAM%2CMETRO%7CtravelAssistance%3Dfalse%7CtripSummaryHash%3D4180974815&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "searchUrl": "https://treinwijzer.ns.nl/idp/login?search=true&originUicCode=8400050&destinationUicCode=8400530&dateTime=2025-04-05T18%3A45%3A12.125933%2B02%3A00&searchForArrival=false&excludeHighSpeedTrains=false&localTrainsOnly=false&searchForAccessibleTrip=false&lang=en&travelAssistance=false",
+            "status": "REGISTRATION_POSSIBLE",
+            "bicycleReservationRequired": false
+        },
+        "modalityListItems": [{
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "5",
+            "accessibilityName": "Intercity"
+        }, {
+            "name": "Intercity",
+            "nameNesProperties": {
+                "color": "text-subtle",
+                "styles": {
+                    "type": "TextStyles",
+                    "strikethrough": false,
+                    "bold": false
+                }
+            },
+            "iconNesProperties": {
+                "color": "text-body",
+                "icon": "train"
+            },
+            "actualTrack": "8",
+            "accessibilityName": "Intercity"
+        }]
+    }],
+    "scrollRequestBackwardContext": "3|OB|MTµ14µ11204µ11204µ11288µ11288µ0µ0µ65861µ11195µ1µ0µ2µ0µ0µ-2147483648µ1µ2|PDHµcf2e38c62aa64d9929de982b9ba39b10|RDµ5042025|RTµ183500|USµ0|RSµINIT",
+    "scrollRequestForwardContext": "3|OF|MTµ14µ11234µ11234µ11319µ11350µ0µ0µ325µ11205µ7µ0µ10µ0µ0µ-2147483648µ1µ2|PDHµcf2e38c62aa64d9929de982b9ba39b10|RDµ5042025|RTµ183500|USµ0|RSµINIT"
+}

--- a/ns-api-test/travel_planner_settings.txt
+++ b/ns-api-test/travel_planner_settings.txt
@@ -1,0 +1,296 @@
+
+Name
+In
+Required
+Type
+Description
+
+lang
+query
+false
+string
+Language to use for localizing the travel advice. Only a small subset of text is translated, mainly notes. Defaults to Dutch
+
+fromStation
+query
+false
+string
+NS station code of the origin station
+
+originUicCode
+query
+false
+string
+UIC code of the origin station
+
+originLat
+query
+false
+number
+Latitude of the origin location. Should be used together with originLng. If the origin is a station, just provide the uicCode instead of the lat/lng
+
+originLng
+query
+false
+number
+Longitude of the origin location. Should be used together with originLat. If the origin is a station, just provide the uicCode instead of the lat/lng
+
+originName
+query
+false
+string
+Name of the origin location. Will be returned in the response
+
+toStation
+query
+false
+string
+NS station code of the destination station
+
+destinationUicCode
+query
+false
+string
+UIC code of the destination station
+
+destinationLat
+query
+false
+number
+Latitude of the destination location. Should be used together with destinationLng. If the destination is a station, just provide the uicCode instead of the lat/lng
+
+destinationLng
+query
+false
+number
+Longitude of the destination location. Should be used together with destinationLat. If the destination is a station, just provide the uicCode instead of the lat/lng
+
+destinationName
+query
+false
+string
+Name of the destination location. Will be returned in the response
+
+viaStation
+query
+false
+string
+NS station code of the via station
+
+viaUicCode
+query
+false
+string
+UIC code of the via station
+
+viaLat
+query
+false
+number
+Latitude of the via location. Should be used together with viaLng. Will only be used for door-to-door trips. If the via location is a station, just provide the uicCode instead of the lat/lng.
+
+viaLng
+query
+false
+number
+Longitude of the via location. Should be used together with viaLat. Will only be used for door-to-door trips. If the via location is a station, just provide the uicCode instead of the lat/lng.
+
+originWalk
+query
+false
+boolean
+Return trip advices with walking options to start travel from origin to a train station (first mile)
+
+originBike
+query
+false
+boolean
+Return trip advices with biking options to start travel from origin to a train station (first mile)
+
+originCar
+query
+false
+boolean
+Return trip advices with car options to start travel from origin to a train station (first mile)
+
+destinationWalk
+query
+false
+boolean
+Return trip advices with walking options to finish travel to the destination (last mile)
+
+destinationBike
+query
+false
+boolean
+Return trip advices with biking options to finish travel to the destination (last mile)
+
+destinationCar
+query
+false
+boolean
+Return trip advices with car options to finish travel to the destination (last mile)
+
+dateTime
+query
+false
+string
+Format - date-time (as date-time in RFC3339). Datetime that the user want to depart from his origin or or arrive at his destination
+
+searchForArrival
+query
+false
+boolean
+If set, the date and time parameters specify the arrival time for the trip search instead of the departure time
+
+departure
+query
+false
+boolean
+Use searchForArrival parameter instead
+
+context
+query
+false
+string
+Parameter specifying that the user wants a next or previous page of the results
+
+shorterChange
+query
+false
+boolean
+Changes the CHANGE_NOT_POSSIBLE status to CHANGE_COULD_BE_POSSIBLE if the traveler can walk twice as fast. Deprecated: the functionality is removed because we do not want to suggest travelers to run.
+
+addChangeTime
+query
+false
+integer
+Format - int32. Extra time in minutes required at all transfers to change trains.
+
+minimalChangeTime
+query
+false
+integer
+Format - int32. Use addChangeTime instead
+
+viaWaitTime
+query
+false
+integer
+Format - int32. Waiting time in minutes at the via location, exclusive of transfer time
+
+originAccessible
+query
+false
+boolean
+Use travelAssistance parameter instead
+
+travelAssistance
+query
+false
+boolean
+Return trip advices from the trip assistance booking engine PAS
+
+travelAssistanceTransferTime
+query
+false
+integer
+Format - int32. Use addChangeTime parameter instead
+
+accessibilityEquipment1
+query
+false
+string
+Accessibility equipment to use when searching for trip assistance options (AVG/PAS)
+
+accessibilityEquipment2
+query
+false
+string
+Accessibility equipment to use when searching for trip assistance options (AVG/PAS)
+
+searchForAccessibleTrip
+query
+false
+boolean
+Return trip advices that are accessible. (might be bookable too)
+
+filterTransportMode
+query
+false
+string
+Could be used to filter for REGIONAL_TRAINS. This parameter is replaced by the localTrainsOnly parameter
+
+localTrainsOnly
+query
+false
+boolean
+Search only for local train options, i.e. sprinter/sneltrein/stoptrein
+
+excludeHighSpeedTrains
+query
+false
+boolean
+Exclude high speed trains from results (including those with a required reservation)
+
+excludeTrainsWithReservationRequired
+query
+false
+boolean
+Exclude trains for domestic trips that require a reservation (e.g. Eurostar)
+
+product
+query
+false
+string
+Name of the product that will be used in Travel
+<select class="form-control" aria-label="Parameter value"><option value="">Select value...</option><option value="GEEN">GEEN</option><option value="OVCHIPKAART_ENKELE_REIS">OVCHIPKAART_ENKELE_REIS</option><option value="OVCHIPKAART_RETOUR">OVCHIPKAART_RETOUR</option><option value="DAL_VOORDEEL">DAL_VOORDEEL</option><option value="ALTIJD_VOORDEEL">ALTIJD_VOORDEEL</option><option value="DAL_VRIJ">DAL_VRIJ</option><option value="WEEKEND_VRIJ">WEEKEND_VRIJ</option><option value="ALTIJD_VRIJ">ALTIJD_VRIJ</option><option value="BUSINESSCARD">BUSINESSCARD</option><option value="BUSINESSCARD_DAL">BUSINESSCARD_DAL</option><option value="STUDENT_WEEK">STUDENT_WEEK</option><option value="STUDENT_WEEKEND">STUDENT_WEEKEND</option><option value="VDU">VDU</option><option value="SAMENREISKORTING">SAMENREISKORTING</option><option value="TRAJECT_VRIJ">TRAJECT_VRIJ</option></select>
+
+
+discount
+query
+false
+string
+Discount of travel to use when calculating product prices
+
+travelClass
+query
+false
+integer
+Format - int32. Class of travel to use when calculating product prices
+
+passing
+query
+false
+boolean
+Show intermediate stops that the journey passes but doesn't stop at (only works for source:HARP not multi-modal trips from negentwee)
+
+travelRequestType
+query
+false
+string
+directionsOnly only plans a google directions (walk/bike/car) advice
+
+disabledTransportModalities
+query
+false
+array
+exclude modalities from trip search
+
+firstMileModality
+query
+false
+string
+Shared modality origin filter to use when querying trips
+
+lastMileModality
+query
+false
+string
+Shared modality destination filter to use when querying trips
+
+entireTripModality
+query
+false
+string
+Shared modality total trip filter to use when querying trips

--- a/ns-api-test/travel_summary.txt
+++ b/ns-api-test/travel_summary.txt
@@ -1,0 +1,168 @@
+--- Travel Plan Summary ---
+
+=== Planning Settings ===
+Origin:      Alkmaar
+Destination: Rotterdam Centraal
+Time:        05-04-2025, 18:44
+
+=== Trip Option 1 ===
+Departure:   05-04-2025, 18:44
+Arrival:     05-04-2025, 20:08
+Duration:    84 minutes
+Transfers:   2
+Status:      NORMAL
+Notes:
+  - € 3.00 supplement
+
+  --- Legs ---
+  Leg 1: IC IC 3071 (Direction: Nijmegen)
+    18:44 Depart Alkmaar (Track 5)
+    19:15 Arrive Amsterdam Sloterdijk (Track 5)
+
+  Leg 2: SPR SPR 8273 (Direction: Hoofddorp)
+    19:25 Depart Amsterdam Sloterdijk (Track 11)
+    19:35 Arrive Schiphol Airport ✈ (Track 4)
+    Transfer Info:
+      - 10 min. transfer time
+
+  Leg 3: ICD ICD 2466 (Direction: Rotterdam Centraal)
+    19:42 Depart Schiphol Airport ✈ (Track 5-6)
+    20:08 Arrive Rotterdam Centraal (Track 11)
+      Note: Supplement
+      Note: Supplement
+    Transfer Info:
+      - 7 min. transfer time
+
+
+=== Trip Option 2 ===
+Departure:   05-04-2025, 18:44
+Arrival:     05-04-2025, 20:35
+Duration:    111 minutes
+Transfers:   2
+Status:      NORMAL
+
+  --- Legs ---
+  Leg 1: IC IC 3071 (Direction: Nijmegen)
+    18:44 Depart Alkmaar (Track 5)
+    19:15 Arrive Amsterdam Sloterdijk (Track 5)
+
+  Leg 2: IC IC 2177 (Direction: Leiden Centraal)
+    19:25 Depart Amsterdam Sloterdijk (Track 7)
+    19:56 Arrive Leiden Centraal (Track 9b)
+    Transfer Info:
+      - 10 min. transfer time
+      - Avoid extra costs: transfer via the station hall
+
+  Leg 3: IC IC 3566 (Direction: Dordrecht)
+    20:02 Depart Leiden Centraal (Track 8b)
+    20:35 Arrive Rotterdam Centraal (Track 7)
+    Transfer Info:
+      - Transfer at same platform
+
+
+=== Trip Option 3 ===
+Departure:   05-04-2025, 18:44
+Arrival:     05-04-2025, 20:40
+Duration:    116 minutes
+Transfers:   1
+Status:      NORMAL
+
+  --- Legs ---
+  Leg 1: IC IC 3071 (Direction: Nijmegen)
+    18:44 Depart Alkmaar (Track 5)
+    19:51 Arrive Utrecht Centraal (Track 19)
+
+  Leg 2: IC IC 2868 (Direction: Rotterdam Centraal)
+    20:03 Depart Utrecht Centraal (Track 8)
+    20:40 Arrive Rotterdam Centraal (Track 14)
+    Transfer Info:
+      - 12 min. transfer time
+
+
+=== Trip Option 4 ===
+Departure:   05-04-2025, 19:02
+Arrival:     05-04-2025, 21:04
+Duration:    122 minutes
+Transfers:   0
+Status:      NORMAL
+
+  --- Legs ---
+  Leg 1: SPR SPR 4075 (Direction: Rotterdam Centraal)
+    19:02 Depart Alkmaar (Track 5)
+    21:04 Arrive Rotterdam Centraal (Track 16)
+
+
+=== Trip Option 5 ===
+Departure:   05-04-2025, 19:14
+Arrival:     05-04-2025, 20:39
+Duration:    85 minutes
+Transfers:   2
+Status:      NORMAL
+Notes:
+  - € 3.00 supplement
+
+  --- Legs ---
+  Leg 1: IC IC 3073 (Direction: Nijmegen)
+    19:14 Depart Alkmaar (Track 5)
+    19:45 Arrive Amsterdam Sloterdijk (Track 5)
+
+  Leg 2: SPR SPR 8275 (Direction: Hoofddorp)
+    19:55 Depart Amsterdam Sloterdijk (Track 11)
+    20:05 Arrive Schiphol Airport ✈ (Track 4)
+    Transfer Info:
+      - 10 min. transfer time
+
+  Leg 3: ECD ECD 9568 (Direction: Bruxelles Midi)
+    20:11 Depart Schiphol Airport ✈ (Track 5-6)
+    20:39 Arrive Rotterdam Centraal (Track 3)
+      Note: Supplement
+      Note: Supplement
+    Transfer Info:
+      - 6 min. transfer time
+
+
+=== Trip Option 6 ===
+Departure:   05-04-2025, 19:14
+Arrival:     05-04-2025, 21:05
+Duration:    111 minutes
+Transfers:   2
+Status:      NORMAL
+
+  --- Legs ---
+  Leg 1: IC IC 3073 (Direction: Nijmegen)
+    19:14 Depart Alkmaar (Track 5)
+    19:45 Arrive Amsterdam Sloterdijk (Track 5)
+
+  Leg 2: IC IC 2179 (Direction: Leiden Centraal)
+    19:55 Depart Amsterdam Sloterdijk (Track 7)
+    20:26 Arrive Leiden Centraal (Track 9b)
+    Transfer Info:
+      - 10 min. transfer time
+      - Avoid extra costs: transfer via the station hall
+
+  Leg 3: IC IC 3568 (Direction: Dordrecht)
+    20:32 Depart Leiden Centraal (Track 8b)
+    21:05 Arrive Rotterdam Centraal (Track 6)
+    Transfer Info:
+      - Transfer at same platform
+
+
+=== Trip Option 7 ===
+Departure:   05-04-2025, 19:14
+Arrival:     05-04-2025, 21:10
+Duration:    116 minutes
+Transfers:   1
+Status:      NORMAL
+
+  --- Legs ---
+  Leg 1: IC IC 3073 (Direction: Nijmegen)
+    19:14 Depart Alkmaar (Track 5)
+    20:21 Arrive Utrecht Centraal (Track 19)
+
+  Leg 2: IC IC 2870 (Direction: Rotterdam Centraal)
+    20:33 Depart Utrecht Centraal (Track 8)
+    21:10 Arrive Rotterdam Centraal (Track 14)
+    Transfer Info:
+      - 12 min. transfer time
+
+--- End of Summary ---

--- a/ns-api-test/tsconfig.json
+++ b/ns-api-test/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
- Introduced a new file `travel_planner_settings.txt` detailing various parameters for the travel planner API, including language, station codes, location coordinates, travel modes, and accessibility options.
- Added a comprehensive `travel_summary.txt` file that outlines multiple trip options from Alkmaar to Rotterdam Centraal, including departure and arrival times, duration, transfers, and notes on each leg of the journey.